### PR TITLE
chore: Migrate dataproc synth.py to bazel 

### DIFF
--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/package-info.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/package-info.java
@@ -15,11 +15,27 @@
  */
 
 /**
- * A client to Google Cloud Dataproc API.
+ * A client to Cloud Dataproc API.
  *
  * <p>The interfaces provided are listed below, along with usage samples.
  *
- * <p>======================= ClusterControllerClient =======================
+ * <p>============================== AutoscalingPolicyServiceClient ==============================
+ *
+ * <p>Service Description: The API interface for managing autoscaling policies in the Dataproc API.
+ *
+ * <p>Sample for AutoscalingPolicyServiceClient:
+ *
+ * <pre>
+ * <code>
+ * try (AutoscalingPolicyServiceClient autoscalingPolicyServiceClient = AutoscalingPolicyServiceClient.create()) {
+ *   String formattedParent = RegionName.format("[PROJECT]", "[REGION]");
+ *   AutoscalingPolicy policy = AutoscalingPolicy.newBuilder().build();
+ *   AutoscalingPolicy response = autoscalingPolicyServiceClient.createAutoscalingPolicy(formattedParent, policy);
+ * }
+ * </code>
+ * </pre>
+ *
+ * ======================= ClusterControllerClient =======================
  *
  * <p>Service Description: The ClusterControllerService provides methods to manage clusters of
  * Compute Engine instances.
@@ -66,22 +82,6 @@
  *   RegionName parent = RegionName.of("[PROJECT]", "[REGION]");
  *   WorkflowTemplate template = WorkflowTemplate.newBuilder().build();
  *   WorkflowTemplate response = workflowTemplateServiceClient.createWorkflowTemplate(parent, template);
- * }
- * </code>
- * </pre>
- *
- * ============================== AutoscalingPolicyServiceClient ==============================
- *
- * <p>Service Description: The API interface for managing autoscaling policies in the Dataproc API.
- *
- * <p>Sample for AutoscalingPolicyServiceClient:
- *
- * <pre>
- * <code>
- * try (AutoscalingPolicyServiceClient autoscalingPolicyServiceClient = AutoscalingPolicyServiceClient.create()) {
- *   String formattedParent = RegionName.format("[PROJECT]", "[REGION]");
- *   AutoscalingPolicy policy = AutoscalingPolicy.newBuilder().build();
- *   AutoscalingPolicy response = autoscalingPolicyServiceClient.createAutoscalingPolicy(formattedParent, policy);
  * }
  * </code>
  * </pre>

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/AutoscalingPolicyServiceStub.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/AutoscalingPolicyServiceStub.java
@@ -32,7 +32,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * Base stub class for Google Cloud Dataproc API.
+ * Base stub class for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/ClusterControllerStub.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/ClusterControllerStub.java
@@ -38,7 +38,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * Base stub class for Google Cloud Dataproc API.
+ * Base stub class for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/GrpcAutoscalingPolicyServiceCallableFactory.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/GrpcAutoscalingPolicyServiceCallableFactory.java
@@ -36,7 +36,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * gRPC callable factory implementation for Google Cloud Dataproc API.
+ * gRPC callable factory implementation for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/GrpcAutoscalingPolicyServiceStub.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/GrpcAutoscalingPolicyServiceStub.java
@@ -43,7 +43,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * gRPC stub implementation for Google Cloud Dataproc API.
+ * gRPC stub implementation for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/GrpcClusterControllerCallableFactory.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/GrpcClusterControllerCallableFactory.java
@@ -36,7 +36,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * gRPC callable factory implementation for Google Cloud Dataproc API.
+ * gRPC callable factory implementation for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/GrpcClusterControllerStub.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/GrpcClusterControllerStub.java
@@ -46,7 +46,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * gRPC stub implementation for Google Cloud Dataproc API.
+ * gRPC stub implementation for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/GrpcJobControllerCallableFactory.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/GrpcJobControllerCallableFactory.java
@@ -36,7 +36,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * gRPC callable factory implementation for Google Cloud Dataproc API.
+ * gRPC callable factory implementation for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/GrpcJobControllerStub.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/GrpcJobControllerStub.java
@@ -41,7 +41,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * gRPC stub implementation for Google Cloud Dataproc API.
+ * gRPC stub implementation for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/GrpcWorkflowTemplateServiceCallableFactory.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/GrpcWorkflowTemplateServiceCallableFactory.java
@@ -36,7 +36,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * gRPC callable factory implementation for Google Cloud Dataproc API.
+ * gRPC callable factory implementation for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/GrpcWorkflowTemplateServiceStub.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/GrpcWorkflowTemplateServiceStub.java
@@ -49,7 +49,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * gRPC stub implementation for Google Cloud Dataproc API.
+ * gRPC stub implementation for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/JobControllerStub.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/JobControllerStub.java
@@ -33,7 +33,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * Base stub class for Google Cloud Dataproc API.
+ * Base stub class for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/WorkflowTemplateServiceStub.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/WorkflowTemplateServiceStub.java
@@ -38,7 +38,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * Base stub class for Google Cloud Dataproc API.
+ * Base stub class for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/package-info.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/package-info.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * A client to Google Cloud Dataproc API.
+ * A client to Cloud Dataproc API.
  *
  * <p>The interfaces provided are listed below, along with usage samples.
  *

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/AutoscalingPolicyServiceStub.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/AutoscalingPolicyServiceStub.java
@@ -32,7 +32,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * Base stub class for Google Cloud Dataproc API.
+ * Base stub class for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/ClusterControllerStub.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/ClusterControllerStub.java
@@ -38,7 +38,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * Base stub class for Google Cloud Dataproc API.
+ * Base stub class for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/GrpcAutoscalingPolicyServiceCallableFactory.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/GrpcAutoscalingPolicyServiceCallableFactory.java
@@ -36,7 +36,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * gRPC callable factory implementation for Google Cloud Dataproc API.
+ * gRPC callable factory implementation for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/GrpcAutoscalingPolicyServiceStub.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/GrpcAutoscalingPolicyServiceStub.java
@@ -43,7 +43,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * gRPC stub implementation for Google Cloud Dataproc API.
+ * gRPC stub implementation for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/GrpcClusterControllerCallableFactory.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/GrpcClusterControllerCallableFactory.java
@@ -36,7 +36,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * gRPC callable factory implementation for Google Cloud Dataproc API.
+ * gRPC callable factory implementation for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/GrpcClusterControllerStub.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/GrpcClusterControllerStub.java
@@ -46,7 +46,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * gRPC stub implementation for Google Cloud Dataproc API.
+ * gRPC stub implementation for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/GrpcJobControllerCallableFactory.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/GrpcJobControllerCallableFactory.java
@@ -36,7 +36,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * gRPC callable factory implementation for Google Cloud Dataproc API.
+ * gRPC callable factory implementation for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/GrpcJobControllerStub.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/GrpcJobControllerStub.java
@@ -41,7 +41,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * gRPC stub implementation for Google Cloud Dataproc API.
+ * gRPC stub implementation for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/GrpcWorkflowTemplateServiceCallableFactory.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/GrpcWorkflowTemplateServiceCallableFactory.java
@@ -36,7 +36,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * gRPC callable factory implementation for Google Cloud Dataproc API.
+ * gRPC callable factory implementation for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/GrpcWorkflowTemplateServiceStub.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/GrpcWorkflowTemplateServiceStub.java
@@ -49,7 +49,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * gRPC stub implementation for Google Cloud Dataproc API.
+ * gRPC stub implementation for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/JobControllerStub.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/JobControllerStub.java
@@ -33,7 +33,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * Base stub class for Google Cloud Dataproc API.
+ * Base stub class for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */

--- a/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/WorkflowTemplateServiceStub.java
+++ b/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1beta2/stub/WorkflowTemplateServiceStub.java
@@ -38,7 +38,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * Base stub class for Google Cloud Dataproc API.
+ * Base stub class for Cloud Dataproc API.
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */

--- a/google-cloud-dataproc/src/test/java/com/google/cloud/dataproc/v1/AutoscalingPolicyServiceClientTest.java
+++ b/google-cloud-dataproc/src/test/java/com/google/cloud/dataproc/v1/AutoscalingPolicyServiceClientTest.java
@@ -42,28 +42,28 @@ import org.junit.Test;
 
 @javax.annotation.Generated("by GAPIC")
 public class AutoscalingPolicyServiceClientTest {
+  private static MockAutoscalingPolicyService mockAutoscalingPolicyService;
   private static MockClusterController mockClusterController;
   private static MockJobController mockJobController;
   private static MockWorkflowTemplateService mockWorkflowTemplateService;
-  private static MockAutoscalingPolicyService mockAutoscalingPolicyService;
   private static MockServiceHelper serviceHelper;
   private AutoscalingPolicyServiceClient client;
   private LocalChannelProvider channelProvider;
 
   @BeforeClass
   public static void startStaticServer() {
+    mockAutoscalingPolicyService = new MockAutoscalingPolicyService();
     mockClusterController = new MockClusterController();
     mockJobController = new MockJobController();
     mockWorkflowTemplateService = new MockWorkflowTemplateService();
-    mockAutoscalingPolicyService = new MockAutoscalingPolicyService();
     serviceHelper =
         new MockServiceHelper(
             UUID.randomUUID().toString(),
             Arrays.<MockGrpcService>asList(
+                mockAutoscalingPolicyService,
                 mockClusterController,
                 mockJobController,
-                mockWorkflowTemplateService,
-                mockAutoscalingPolicyService));
+                mockWorkflowTemplateService));
     serviceHelper.start();
   }
 

--- a/google-cloud-dataproc/src/test/java/com/google/cloud/dataproc/v1/ClusterControllerClientTest.java
+++ b/google-cloud-dataproc/src/test/java/com/google/cloud/dataproc/v1/ClusterControllerClientTest.java
@@ -47,28 +47,28 @@ import org.junit.Test;
 
 @javax.annotation.Generated("by GAPIC")
 public class ClusterControllerClientTest {
+  private static MockAutoscalingPolicyService mockAutoscalingPolicyService;
   private static MockClusterController mockClusterController;
   private static MockJobController mockJobController;
   private static MockWorkflowTemplateService mockWorkflowTemplateService;
-  private static MockAutoscalingPolicyService mockAutoscalingPolicyService;
   private static MockServiceHelper serviceHelper;
   private ClusterControllerClient client;
   private LocalChannelProvider channelProvider;
 
   @BeforeClass
   public static void startStaticServer() {
+    mockAutoscalingPolicyService = new MockAutoscalingPolicyService();
     mockClusterController = new MockClusterController();
     mockJobController = new MockJobController();
     mockWorkflowTemplateService = new MockWorkflowTemplateService();
-    mockAutoscalingPolicyService = new MockAutoscalingPolicyService();
     serviceHelper =
         new MockServiceHelper(
             UUID.randomUUID().toString(),
             Arrays.<MockGrpcService>asList(
+                mockAutoscalingPolicyService,
                 mockClusterController,
                 mockJobController,
-                mockWorkflowTemplateService,
-                mockAutoscalingPolicyService));
+                mockWorkflowTemplateService));
     serviceHelper.start();
   }
 

--- a/google-cloud-dataproc/src/test/java/com/google/cloud/dataproc/v1/JobControllerClientTest.java
+++ b/google-cloud-dataproc/src/test/java/com/google/cloud/dataproc/v1/JobControllerClientTest.java
@@ -43,28 +43,28 @@ import org.junit.Test;
 
 @javax.annotation.Generated("by GAPIC")
 public class JobControllerClientTest {
+  private static MockAutoscalingPolicyService mockAutoscalingPolicyService;
   private static MockClusterController mockClusterController;
   private static MockJobController mockJobController;
   private static MockWorkflowTemplateService mockWorkflowTemplateService;
-  private static MockAutoscalingPolicyService mockAutoscalingPolicyService;
   private static MockServiceHelper serviceHelper;
   private JobControllerClient client;
   private LocalChannelProvider channelProvider;
 
   @BeforeClass
   public static void startStaticServer() {
+    mockAutoscalingPolicyService = new MockAutoscalingPolicyService();
     mockClusterController = new MockClusterController();
     mockJobController = new MockJobController();
     mockWorkflowTemplateService = new MockWorkflowTemplateService();
-    mockAutoscalingPolicyService = new MockAutoscalingPolicyService();
     serviceHelper =
         new MockServiceHelper(
             UUID.randomUUID().toString(),
             Arrays.<MockGrpcService>asList(
+                mockAutoscalingPolicyService,
                 mockClusterController,
                 mockJobController,
-                mockWorkflowTemplateService,
-                mockAutoscalingPolicyService));
+                mockWorkflowTemplateService));
     serviceHelper.start();
   }
 

--- a/google-cloud-dataproc/src/test/java/com/google/cloud/dataproc/v1/WorkflowTemplateServiceClientTest.java
+++ b/google-cloud-dataproc/src/test/java/com/google/cloud/dataproc/v1/WorkflowTemplateServiceClientTest.java
@@ -48,28 +48,28 @@ import org.junit.Test;
 
 @javax.annotation.Generated("by GAPIC")
 public class WorkflowTemplateServiceClientTest {
+  private static MockAutoscalingPolicyService mockAutoscalingPolicyService;
   private static MockClusterController mockClusterController;
   private static MockJobController mockJobController;
   private static MockWorkflowTemplateService mockWorkflowTemplateService;
-  private static MockAutoscalingPolicyService mockAutoscalingPolicyService;
   private static MockServiceHelper serviceHelper;
   private WorkflowTemplateServiceClient client;
   private LocalChannelProvider channelProvider;
 
   @BeforeClass
   public static void startStaticServer() {
+    mockAutoscalingPolicyService = new MockAutoscalingPolicyService();
     mockClusterController = new MockClusterController();
     mockJobController = new MockJobController();
     mockWorkflowTemplateService = new MockWorkflowTemplateService();
-    mockAutoscalingPolicyService = new MockAutoscalingPolicyService();
     serviceHelper =
         new MockServiceHelper(
             UUID.randomUUID().toString(),
             Arrays.<MockGrpcService>asList(
+                mockAutoscalingPolicyService,
                 mockClusterController,
                 mockJobController,
-                mockWorkflowTemplateService,
-                mockAutoscalingPolicyService));
+                mockWorkflowTemplateService));
     serviceHelper.start();
   }
 

--- a/grpc-google-cloud-dataproc-v1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-dataproc-v1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 0.120.1 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/dataproc/v1beta2/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-dataproc-v1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-dataproc-v1/clirr-ignored-differences.xml
@@ -4,7 +4,7 @@
   <difference>
     <!-- TODO: remove after 0.120.1 released -->
     <differenceType>6001</differenceType>
-    <className>com/google/cloud/dataproc/v1beta2/*Grpc</className>
+    <className>com/google/cloud/dataproc/v1/*Grpc</className>
     <field>METHOD_*</field>
   </difference>
 </differences>

--- a/grpc-google-cloud-dataproc-v1/src/main/java/com/google/cloud/dataproc/v1/AutoscalingPolicyServiceGrpc.java
+++ b/grpc-google-cloud-dataproc-v1/src/main/java/com/google/cloud/dataproc/v1/AutoscalingPolicyServiceGrpc.java
@@ -31,7 +31,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dataproc/v1/autoscaling_policies.proto")
 public final class AutoscalingPolicyServiceGrpc {
 
@@ -40,30 +40,20 @@ public final class AutoscalingPolicyServiceGrpc {
   public static final String SERVICE_NAME = "google.cloud.dataproc.v1.AutoscalingPolicyService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateAutoscalingPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.CreateAutoscalingPolicyRequest,
-          com.google.cloud.dataproc.v1.AutoscalingPolicy>
-      METHOD_CREATE_AUTOSCALING_POLICY = getCreateAutoscalingPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.CreateAutoscalingPolicyRequest,
           com.google.cloud.dataproc.v1.AutoscalingPolicy>
       getCreateAutoscalingPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateAutoscalingPolicy",
+      requestType = com.google.cloud.dataproc.v1.CreateAutoscalingPolicyRequest.class,
+      responseType = com.google.cloud.dataproc.v1.AutoscalingPolicy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.CreateAutoscalingPolicyRequest,
           com.google.cloud.dataproc.v1.AutoscalingPolicy>
       getCreateAutoscalingPolicyMethod() {
-    return getCreateAutoscalingPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.CreateAutoscalingPolicyRequest,
-          com.google.cloud.dataproc.v1.AutoscalingPolicy>
-      getCreateAutoscalingPolicyMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.CreateAutoscalingPolicyRequest,
             com.google.cloud.dataproc.v1.AutoscalingPolicy>
@@ -83,9 +73,7 @@ public final class AutoscalingPolicyServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.AutoscalingPolicyService",
-                              "CreateAutoscalingPolicy"))
+                          generateFullMethodName(SERVICE_NAME, "CreateAutoscalingPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -104,30 +92,20 @@ public final class AutoscalingPolicyServiceGrpc {
     return getCreateAutoscalingPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateAutoscalingPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.UpdateAutoscalingPolicyRequest,
-          com.google.cloud.dataproc.v1.AutoscalingPolicy>
-      METHOD_UPDATE_AUTOSCALING_POLICY = getUpdateAutoscalingPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.UpdateAutoscalingPolicyRequest,
           com.google.cloud.dataproc.v1.AutoscalingPolicy>
       getUpdateAutoscalingPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateAutoscalingPolicy",
+      requestType = com.google.cloud.dataproc.v1.UpdateAutoscalingPolicyRequest.class,
+      responseType = com.google.cloud.dataproc.v1.AutoscalingPolicy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.UpdateAutoscalingPolicyRequest,
           com.google.cloud.dataproc.v1.AutoscalingPolicy>
       getUpdateAutoscalingPolicyMethod() {
-    return getUpdateAutoscalingPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.UpdateAutoscalingPolicyRequest,
-          com.google.cloud.dataproc.v1.AutoscalingPolicy>
-      getUpdateAutoscalingPolicyMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.UpdateAutoscalingPolicyRequest,
             com.google.cloud.dataproc.v1.AutoscalingPolicy>
@@ -147,9 +125,7 @@ public final class AutoscalingPolicyServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.AutoscalingPolicyService",
-                              "UpdateAutoscalingPolicy"))
+                          generateFullMethodName(SERVICE_NAME, "UpdateAutoscalingPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -168,30 +144,20 @@ public final class AutoscalingPolicyServiceGrpc {
     return getUpdateAutoscalingPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetAutoscalingPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.GetAutoscalingPolicyRequest,
-          com.google.cloud.dataproc.v1.AutoscalingPolicy>
-      METHOD_GET_AUTOSCALING_POLICY = getGetAutoscalingPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.GetAutoscalingPolicyRequest,
           com.google.cloud.dataproc.v1.AutoscalingPolicy>
       getGetAutoscalingPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetAutoscalingPolicy",
+      requestType = com.google.cloud.dataproc.v1.GetAutoscalingPolicyRequest.class,
+      responseType = com.google.cloud.dataproc.v1.AutoscalingPolicy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.GetAutoscalingPolicyRequest,
           com.google.cloud.dataproc.v1.AutoscalingPolicy>
       getGetAutoscalingPolicyMethod() {
-    return getGetAutoscalingPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.GetAutoscalingPolicyRequest,
-          com.google.cloud.dataproc.v1.AutoscalingPolicy>
-      getGetAutoscalingPolicyMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.GetAutoscalingPolicyRequest,
             com.google.cloud.dataproc.v1.AutoscalingPolicy>
@@ -210,9 +176,7 @@ public final class AutoscalingPolicyServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.AutoscalingPolicyService",
-                              "GetAutoscalingPolicy"))
+                          generateFullMethodName(SERVICE_NAME, "GetAutoscalingPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -231,30 +195,20 @@ public final class AutoscalingPolicyServiceGrpc {
     return getGetAutoscalingPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListAutoscalingPoliciesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.ListAutoscalingPoliciesRequest,
-          com.google.cloud.dataproc.v1.ListAutoscalingPoliciesResponse>
-      METHOD_LIST_AUTOSCALING_POLICIES = getListAutoscalingPoliciesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.ListAutoscalingPoliciesRequest,
           com.google.cloud.dataproc.v1.ListAutoscalingPoliciesResponse>
       getListAutoscalingPoliciesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListAutoscalingPolicies",
+      requestType = com.google.cloud.dataproc.v1.ListAutoscalingPoliciesRequest.class,
+      responseType = com.google.cloud.dataproc.v1.ListAutoscalingPoliciesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.ListAutoscalingPoliciesRequest,
           com.google.cloud.dataproc.v1.ListAutoscalingPoliciesResponse>
       getListAutoscalingPoliciesMethod() {
-    return getListAutoscalingPoliciesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.ListAutoscalingPoliciesRequest,
-          com.google.cloud.dataproc.v1.ListAutoscalingPoliciesResponse>
-      getListAutoscalingPoliciesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.ListAutoscalingPoliciesRequest,
             com.google.cloud.dataproc.v1.ListAutoscalingPoliciesResponse>
@@ -274,9 +228,7 @@ public final class AutoscalingPolicyServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.AutoscalingPolicyService",
-                              "ListAutoscalingPolicies"))
+                          generateFullMethodName(SERVICE_NAME, "ListAutoscalingPolicies"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -296,26 +248,18 @@ public final class AutoscalingPolicyServiceGrpc {
     return getListAutoscalingPoliciesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteAutoscalingPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.DeleteAutoscalingPolicyRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_AUTOSCALING_POLICY = getDeleteAutoscalingPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.DeleteAutoscalingPolicyRequest, com.google.protobuf.Empty>
       getDeleteAutoscalingPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteAutoscalingPolicy",
+      requestType = com.google.cloud.dataproc.v1.DeleteAutoscalingPolicyRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.DeleteAutoscalingPolicyRequest, com.google.protobuf.Empty>
       getDeleteAutoscalingPolicyMethod() {
-    return getDeleteAutoscalingPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.DeleteAutoscalingPolicyRequest, com.google.protobuf.Empty>
-      getDeleteAutoscalingPolicyMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.DeleteAutoscalingPolicyRequest, com.google.protobuf.Empty>
         getDeleteAutoscalingPolicyMethod;
@@ -334,9 +278,7 @@ public final class AutoscalingPolicyServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.AutoscalingPolicyService",
-                              "DeleteAutoscalingPolicy"))
+                          generateFullMethodName(SERVICE_NAME, "DeleteAutoscalingPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -357,19 +299,43 @@ public final class AutoscalingPolicyServiceGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static AutoscalingPolicyServiceStub newStub(io.grpc.Channel channel) {
-    return new AutoscalingPolicyServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AutoscalingPolicyServiceStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AutoscalingPolicyServiceStub>() {
+          @java.lang.Override
+          public AutoscalingPolicyServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AutoscalingPolicyServiceStub(channel, callOptions);
+          }
+        };
+    return AutoscalingPolicyServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static AutoscalingPolicyServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new AutoscalingPolicyServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AutoscalingPolicyServiceBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AutoscalingPolicyServiceBlockingStub>() {
+          @java.lang.Override
+          public AutoscalingPolicyServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AutoscalingPolicyServiceBlockingStub(channel, callOptions);
+          }
+        };
+    return AutoscalingPolicyServiceBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static AutoscalingPolicyServiceFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new AutoscalingPolicyServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AutoscalingPolicyServiceFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AutoscalingPolicyServiceFutureStub>() {
+          @java.lang.Override
+          public AutoscalingPolicyServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AutoscalingPolicyServiceFutureStub(channel, callOptions);
+          }
+        };
+    return AutoscalingPolicyServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -393,7 +359,7 @@ public final class AutoscalingPolicyServiceGrpc {
         com.google.cloud.dataproc.v1.CreateAutoscalingPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.AutoscalingPolicy>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateAutoscalingPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateAutoscalingPolicyMethod(), responseObserver);
     }
 
     /**
@@ -409,7 +375,7 @@ public final class AutoscalingPolicyServiceGrpc {
         com.google.cloud.dataproc.v1.UpdateAutoscalingPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.AutoscalingPolicy>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateAutoscalingPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateAutoscalingPolicyMethod(), responseObserver);
     }
 
     /**
@@ -423,7 +389,7 @@ public final class AutoscalingPolicyServiceGrpc {
         com.google.cloud.dataproc.v1.GetAutoscalingPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.AutoscalingPolicy>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetAutoscalingPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetAutoscalingPolicyMethod(), responseObserver);
     }
 
     /**
@@ -437,7 +403,7 @@ public final class AutoscalingPolicyServiceGrpc {
         com.google.cloud.dataproc.v1.ListAutoscalingPoliciesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.ListAutoscalingPoliciesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListAutoscalingPoliciesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListAutoscalingPoliciesMethod(), responseObserver);
     }
 
     /**
@@ -451,42 +417,42 @@ public final class AutoscalingPolicyServiceGrpc {
     public void deleteAutoscalingPolicy(
         com.google.cloud.dataproc.v1.DeleteAutoscalingPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteAutoscalingPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteAutoscalingPolicyMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getCreateAutoscalingPolicyMethodHelper(),
+              getCreateAutoscalingPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.CreateAutoscalingPolicyRequest,
                       com.google.cloud.dataproc.v1.AutoscalingPolicy>(
                       this, METHODID_CREATE_AUTOSCALING_POLICY)))
           .addMethod(
-              getUpdateAutoscalingPolicyMethodHelper(),
+              getUpdateAutoscalingPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.UpdateAutoscalingPolicyRequest,
                       com.google.cloud.dataproc.v1.AutoscalingPolicy>(
                       this, METHODID_UPDATE_AUTOSCALING_POLICY)))
           .addMethod(
-              getGetAutoscalingPolicyMethodHelper(),
+              getGetAutoscalingPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.GetAutoscalingPolicyRequest,
                       com.google.cloud.dataproc.v1.AutoscalingPolicy>(
                       this, METHODID_GET_AUTOSCALING_POLICY)))
           .addMethod(
-              getListAutoscalingPoliciesMethodHelper(),
+              getListAutoscalingPoliciesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.ListAutoscalingPoliciesRequest,
                       com.google.cloud.dataproc.v1.ListAutoscalingPoliciesResponse>(
                       this, METHODID_LIST_AUTOSCALING_POLICIES)))
           .addMethod(
-              getDeleteAutoscalingPolicyMethodHelper(),
+              getDeleteAutoscalingPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.DeleteAutoscalingPolicyRequest,
@@ -504,11 +470,7 @@ public final class AutoscalingPolicyServiceGrpc {
    * </pre>
    */
   public static final class AutoscalingPolicyServiceStub
-      extends io.grpc.stub.AbstractStub<AutoscalingPolicyServiceStub> {
-    private AutoscalingPolicyServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<AutoscalingPolicyServiceStub> {
     private AutoscalingPolicyServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -531,7 +493,7 @@ public final class AutoscalingPolicyServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.AutoscalingPolicy>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateAutoscalingPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateAutoscalingPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -550,7 +512,7 @@ public final class AutoscalingPolicyServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.AutoscalingPolicy>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateAutoscalingPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateAutoscalingPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -567,7 +529,7 @@ public final class AutoscalingPolicyServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.AutoscalingPolicy>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetAutoscalingPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetAutoscalingPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -584,7 +546,7 @@ public final class AutoscalingPolicyServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.ListAutoscalingPoliciesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListAutoscalingPoliciesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListAutoscalingPoliciesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -601,7 +563,7 @@ public final class AutoscalingPolicyServiceGrpc {
         com.google.cloud.dataproc.v1.DeleteAutoscalingPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteAutoscalingPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteAutoscalingPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -616,11 +578,7 @@ public final class AutoscalingPolicyServiceGrpc {
    * </pre>
    */
   public static final class AutoscalingPolicyServiceBlockingStub
-      extends io.grpc.stub.AbstractStub<AutoscalingPolicyServiceBlockingStub> {
-    private AutoscalingPolicyServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<AutoscalingPolicyServiceBlockingStub> {
     private AutoscalingPolicyServiceBlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -642,7 +600,7 @@ public final class AutoscalingPolicyServiceGrpc {
     public com.google.cloud.dataproc.v1.AutoscalingPolicy createAutoscalingPolicy(
         com.google.cloud.dataproc.v1.CreateAutoscalingPolicyRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateAutoscalingPolicyMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateAutoscalingPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -657,7 +615,7 @@ public final class AutoscalingPolicyServiceGrpc {
     public com.google.cloud.dataproc.v1.AutoscalingPolicy updateAutoscalingPolicy(
         com.google.cloud.dataproc.v1.UpdateAutoscalingPolicyRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateAutoscalingPolicyMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateAutoscalingPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -670,7 +628,7 @@ public final class AutoscalingPolicyServiceGrpc {
     public com.google.cloud.dataproc.v1.AutoscalingPolicy getAutoscalingPolicy(
         com.google.cloud.dataproc.v1.GetAutoscalingPolicyRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetAutoscalingPolicyMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetAutoscalingPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -683,7 +641,7 @@ public final class AutoscalingPolicyServiceGrpc {
     public com.google.cloud.dataproc.v1.ListAutoscalingPoliciesResponse listAutoscalingPolicies(
         com.google.cloud.dataproc.v1.ListAutoscalingPoliciesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListAutoscalingPoliciesMethodHelper(), getCallOptions(), request);
+          getChannel(), getListAutoscalingPoliciesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -697,7 +655,7 @@ public final class AutoscalingPolicyServiceGrpc {
     public com.google.protobuf.Empty deleteAutoscalingPolicy(
         com.google.cloud.dataproc.v1.DeleteAutoscalingPolicyRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteAutoscalingPolicyMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteAutoscalingPolicyMethod(), getCallOptions(), request);
     }
   }
 
@@ -710,11 +668,7 @@ public final class AutoscalingPolicyServiceGrpc {
    * </pre>
    */
   public static final class AutoscalingPolicyServiceFutureStub
-      extends io.grpc.stub.AbstractStub<AutoscalingPolicyServiceFutureStub> {
-    private AutoscalingPolicyServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<AutoscalingPolicyServiceFutureStub> {
     private AutoscalingPolicyServiceFutureStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -738,8 +692,7 @@ public final class AutoscalingPolicyServiceGrpc {
         createAutoscalingPolicy(
             com.google.cloud.dataproc.v1.CreateAutoscalingPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateAutoscalingPolicyMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getCreateAutoscalingPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -756,8 +709,7 @@ public final class AutoscalingPolicyServiceGrpc {
         updateAutoscalingPolicy(
             com.google.cloud.dataproc.v1.UpdateAutoscalingPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateAutoscalingPolicyMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getUpdateAutoscalingPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -771,7 +723,7 @@ public final class AutoscalingPolicyServiceGrpc {
             com.google.cloud.dataproc.v1.AutoscalingPolicy>
         getAutoscalingPolicy(com.google.cloud.dataproc.v1.GetAutoscalingPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetAutoscalingPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetAutoscalingPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -786,8 +738,7 @@ public final class AutoscalingPolicyServiceGrpc {
         listAutoscalingPolicies(
             com.google.cloud.dataproc.v1.ListAutoscalingPoliciesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListAutoscalingPoliciesMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getListAutoscalingPoliciesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -802,8 +753,7 @@ public final class AutoscalingPolicyServiceGrpc {
         deleteAutoscalingPolicy(
             com.google.cloud.dataproc.v1.DeleteAutoscalingPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteAutoscalingPolicyMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getDeleteAutoscalingPolicyMethod(), getCallOptions()), request);
     }
   }
 
@@ -924,11 +874,11 @@ public final class AutoscalingPolicyServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new AutoscalingPolicyServiceFileDescriptorSupplier())
-                      .addMethod(getCreateAutoscalingPolicyMethodHelper())
-                      .addMethod(getUpdateAutoscalingPolicyMethodHelper())
-                      .addMethod(getGetAutoscalingPolicyMethodHelper())
-                      .addMethod(getListAutoscalingPoliciesMethodHelper())
-                      .addMethod(getDeleteAutoscalingPolicyMethodHelper())
+                      .addMethod(getCreateAutoscalingPolicyMethod())
+                      .addMethod(getUpdateAutoscalingPolicyMethod())
+                      .addMethod(getGetAutoscalingPolicyMethod())
+                      .addMethod(getListAutoscalingPoliciesMethod())
+                      .addMethod(getDeleteAutoscalingPolicyMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dataproc-v1/src/main/java/com/google/cloud/dataproc/v1/ClusterControllerGrpc.java
+++ b/grpc-google-cloud-dataproc-v1/src/main/java/com/google/cloud/dataproc/v1/ClusterControllerGrpc.java
@@ -31,7 +31,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dataproc/v1/clusters.proto")
 public final class ClusterControllerGrpc {
 
@@ -40,26 +40,18 @@ public final class ClusterControllerGrpc {
   public static final String SERVICE_NAME = "google.cloud.dataproc.v1.ClusterController";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateClusterMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.CreateClusterRequest, com.google.longrunning.Operation>
-      METHOD_CREATE_CLUSTER = getCreateClusterMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.CreateClusterRequest, com.google.longrunning.Operation>
       getCreateClusterMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateCluster",
+      requestType = com.google.cloud.dataproc.v1.CreateClusterRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.CreateClusterRequest, com.google.longrunning.Operation>
       getCreateClusterMethod() {
-    return getCreateClusterMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.CreateClusterRequest, com.google.longrunning.Operation>
-      getCreateClusterMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.CreateClusterRequest, com.google.longrunning.Operation>
         getCreateClusterMethod;
@@ -73,9 +65,7 @@ public final class ClusterControllerGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.ClusterController", "CreateCluster"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateCluster"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -93,26 +83,18 @@ public final class ClusterControllerGrpc {
     return getCreateClusterMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateClusterMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.UpdateClusterRequest, com.google.longrunning.Operation>
-      METHOD_UPDATE_CLUSTER = getUpdateClusterMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.UpdateClusterRequest, com.google.longrunning.Operation>
       getUpdateClusterMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateCluster",
+      requestType = com.google.cloud.dataproc.v1.UpdateClusterRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.UpdateClusterRequest, com.google.longrunning.Operation>
       getUpdateClusterMethod() {
-    return getUpdateClusterMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.UpdateClusterRequest, com.google.longrunning.Operation>
-      getUpdateClusterMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.UpdateClusterRequest, com.google.longrunning.Operation>
         getUpdateClusterMethod;
@@ -126,9 +108,7 @@ public final class ClusterControllerGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.ClusterController", "UpdateCluster"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateCluster"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -146,26 +126,18 @@ public final class ClusterControllerGrpc {
     return getUpdateClusterMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteClusterMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.DeleteClusterRequest, com.google.longrunning.Operation>
-      METHOD_DELETE_CLUSTER = getDeleteClusterMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.DeleteClusterRequest, com.google.longrunning.Operation>
       getDeleteClusterMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteCluster",
+      requestType = com.google.cloud.dataproc.v1.DeleteClusterRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.DeleteClusterRequest, com.google.longrunning.Operation>
       getDeleteClusterMethod() {
-    return getDeleteClusterMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.DeleteClusterRequest, com.google.longrunning.Operation>
-      getDeleteClusterMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.DeleteClusterRequest, com.google.longrunning.Operation>
         getDeleteClusterMethod;
@@ -179,9 +151,7 @@ public final class ClusterControllerGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.ClusterController", "DeleteCluster"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteCluster"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -199,26 +169,18 @@ public final class ClusterControllerGrpc {
     return getDeleteClusterMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetClusterMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.GetClusterRequest, com.google.cloud.dataproc.v1.Cluster>
-      METHOD_GET_CLUSTER = getGetClusterMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.GetClusterRequest, com.google.cloud.dataproc.v1.Cluster>
       getGetClusterMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetCluster",
+      requestType = com.google.cloud.dataproc.v1.GetClusterRequest.class,
+      responseType = com.google.cloud.dataproc.v1.Cluster.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.GetClusterRequest, com.google.cloud.dataproc.v1.Cluster>
       getGetClusterMethod() {
-    return getGetClusterMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.GetClusterRequest, com.google.cloud.dataproc.v1.Cluster>
-      getGetClusterMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.GetClusterRequest, com.google.cloud.dataproc.v1.Cluster>
         getGetClusterMethod;
@@ -232,9 +194,7 @@ public final class ClusterControllerGrpc {
                           com.google.cloud.dataproc.v1.Cluster>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.ClusterController", "GetCluster"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetCluster"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -251,30 +211,20 @@ public final class ClusterControllerGrpc {
     return getGetClusterMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListClustersMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.ListClustersRequest,
-          com.google.cloud.dataproc.v1.ListClustersResponse>
-      METHOD_LIST_CLUSTERS = getListClustersMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.ListClustersRequest,
           com.google.cloud.dataproc.v1.ListClustersResponse>
       getListClustersMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListClusters",
+      requestType = com.google.cloud.dataproc.v1.ListClustersRequest.class,
+      responseType = com.google.cloud.dataproc.v1.ListClustersResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.ListClustersRequest,
           com.google.cloud.dataproc.v1.ListClustersResponse>
       getListClustersMethod() {
-    return getListClustersMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.ListClustersRequest,
-          com.google.cloud.dataproc.v1.ListClustersResponse>
-      getListClustersMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.ListClustersRequest,
             com.google.cloud.dataproc.v1.ListClustersResponse>
@@ -289,9 +239,7 @@ public final class ClusterControllerGrpc {
                           com.google.cloud.dataproc.v1.ListClustersResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.ClusterController", "ListClusters"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListClusters"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -310,26 +258,18 @@ public final class ClusterControllerGrpc {
     return getListClustersMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDiagnoseClusterMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.DiagnoseClusterRequest, com.google.longrunning.Operation>
-      METHOD_DIAGNOSE_CLUSTER = getDiagnoseClusterMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.DiagnoseClusterRequest, com.google.longrunning.Operation>
       getDiagnoseClusterMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DiagnoseCluster",
+      requestType = com.google.cloud.dataproc.v1.DiagnoseClusterRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.DiagnoseClusterRequest, com.google.longrunning.Operation>
       getDiagnoseClusterMethod() {
-    return getDiagnoseClusterMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.DiagnoseClusterRequest, com.google.longrunning.Operation>
-      getDiagnoseClusterMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.DiagnoseClusterRequest, com.google.longrunning.Operation>
         getDiagnoseClusterMethod;
@@ -343,9 +283,7 @@ public final class ClusterControllerGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.ClusterController", "DiagnoseCluster"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DiagnoseCluster"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -365,19 +303,43 @@ public final class ClusterControllerGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static ClusterControllerStub newStub(io.grpc.Channel channel) {
-    return new ClusterControllerStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ClusterControllerStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ClusterControllerStub>() {
+          @java.lang.Override
+          public ClusterControllerStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ClusterControllerStub(channel, callOptions);
+          }
+        };
+    return ClusterControllerStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static ClusterControllerBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new ClusterControllerBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ClusterControllerBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ClusterControllerBlockingStub>() {
+          @java.lang.Override
+          public ClusterControllerBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ClusterControllerBlockingStub(channel, callOptions);
+          }
+        };
+    return ClusterControllerBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static ClusterControllerFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new ClusterControllerFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ClusterControllerFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ClusterControllerFutureStub>() {
+          @java.lang.Override
+          public ClusterControllerFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ClusterControllerFutureStub(channel, callOptions);
+          }
+        };
+    return ClusterControllerFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -402,7 +364,7 @@ public final class ClusterControllerGrpc {
     public void createCluster(
         com.google.cloud.dataproc.v1.CreateClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateClusterMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateClusterMethod(), responseObserver);
     }
 
     /**
@@ -417,7 +379,7 @@ public final class ClusterControllerGrpc {
     public void updateCluster(
         com.google.cloud.dataproc.v1.UpdateClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateClusterMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateClusterMethod(), responseObserver);
     }
 
     /**
@@ -432,7 +394,7 @@ public final class ClusterControllerGrpc {
     public void deleteCluster(
         com.google.cloud.dataproc.v1.DeleteClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteClusterMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteClusterMethod(), responseObserver);
     }
 
     /**
@@ -445,7 +407,7 @@ public final class ClusterControllerGrpc {
     public void getCluster(
         com.google.cloud.dataproc.v1.GetClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.Cluster> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetClusterMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetClusterMethod(), responseObserver);
     }
 
     /**
@@ -459,7 +421,7 @@ public final class ClusterControllerGrpc {
         com.google.cloud.dataproc.v1.ListClustersRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.ListClustersResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListClustersMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListClustersMethod(), responseObserver);
     }
 
     /**
@@ -478,45 +440,45 @@ public final class ClusterControllerGrpc {
     public void diagnoseCluster(
         com.google.cloud.dataproc.v1.DiagnoseClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getDiagnoseClusterMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDiagnoseClusterMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getCreateClusterMethodHelper(),
+              getCreateClusterMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.CreateClusterRequest,
                       com.google.longrunning.Operation>(this, METHODID_CREATE_CLUSTER)))
           .addMethod(
-              getUpdateClusterMethodHelper(),
+              getUpdateClusterMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.UpdateClusterRequest,
                       com.google.longrunning.Operation>(this, METHODID_UPDATE_CLUSTER)))
           .addMethod(
-              getDeleteClusterMethodHelper(),
+              getDeleteClusterMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.DeleteClusterRequest,
                       com.google.longrunning.Operation>(this, METHODID_DELETE_CLUSTER)))
           .addMethod(
-              getGetClusterMethodHelper(),
+              getGetClusterMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.GetClusterRequest,
                       com.google.cloud.dataproc.v1.Cluster>(this, METHODID_GET_CLUSTER)))
           .addMethod(
-              getListClustersMethodHelper(),
+              getListClustersMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.ListClustersRequest,
                       com.google.cloud.dataproc.v1.ListClustersResponse>(
                       this, METHODID_LIST_CLUSTERS)))
           .addMethod(
-              getDiagnoseClusterMethodHelper(),
+              getDiagnoseClusterMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.DiagnoseClusterRequest,
@@ -534,11 +496,7 @@ public final class ClusterControllerGrpc {
    * </pre>
    */
   public static final class ClusterControllerStub
-      extends io.grpc.stub.AbstractStub<ClusterControllerStub> {
-    private ClusterControllerStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<ClusterControllerStub> {
     private ClusterControllerStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -562,7 +520,7 @@ public final class ClusterControllerGrpc {
         com.google.cloud.dataproc.v1.CreateClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateClusterMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateClusterMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -580,7 +538,7 @@ public final class ClusterControllerGrpc {
         com.google.cloud.dataproc.v1.UpdateClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateClusterMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateClusterMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -598,7 +556,7 @@ public final class ClusterControllerGrpc {
         com.google.cloud.dataproc.v1.DeleteClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteClusterMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteClusterMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -614,9 +572,7 @@ public final class ClusterControllerGrpc {
         com.google.cloud.dataproc.v1.GetClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.Cluster> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetClusterMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetClusterMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -631,7 +587,7 @@ public final class ClusterControllerGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.ListClustersResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListClustersMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListClustersMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -653,7 +609,7 @@ public final class ClusterControllerGrpc {
         com.google.cloud.dataproc.v1.DiagnoseClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDiagnoseClusterMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDiagnoseClusterMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -668,11 +624,7 @@ public final class ClusterControllerGrpc {
    * </pre>
    */
   public static final class ClusterControllerBlockingStub
-      extends io.grpc.stub.AbstractStub<ClusterControllerBlockingStub> {
-    private ClusterControllerBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<ClusterControllerBlockingStub> {
     private ClusterControllerBlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -695,8 +647,7 @@ public final class ClusterControllerGrpc {
      */
     public com.google.longrunning.Operation createCluster(
         com.google.cloud.dataproc.v1.CreateClusterRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateClusterMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateClusterMethod(), getCallOptions(), request);
     }
 
     /**
@@ -710,8 +661,7 @@ public final class ClusterControllerGrpc {
      */
     public com.google.longrunning.Operation updateCluster(
         com.google.cloud.dataproc.v1.UpdateClusterRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateClusterMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateClusterMethod(), getCallOptions(), request);
     }
 
     /**
@@ -725,8 +675,7 @@ public final class ClusterControllerGrpc {
      */
     public com.google.longrunning.Operation deleteCluster(
         com.google.cloud.dataproc.v1.DeleteClusterRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteClusterMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteClusterMethod(), getCallOptions(), request);
     }
 
     /**
@@ -738,8 +687,7 @@ public final class ClusterControllerGrpc {
      */
     public com.google.cloud.dataproc.v1.Cluster getCluster(
         com.google.cloud.dataproc.v1.GetClusterRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetClusterMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetClusterMethod(), getCallOptions(), request);
     }
 
     /**
@@ -751,8 +699,7 @@ public final class ClusterControllerGrpc {
      */
     public com.google.cloud.dataproc.v1.ListClustersResponse listClusters(
         com.google.cloud.dataproc.v1.ListClustersRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListClustersMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListClustersMethod(), getCallOptions(), request);
     }
 
     /**
@@ -770,8 +717,7 @@ public final class ClusterControllerGrpc {
      */
     public com.google.longrunning.Operation diagnoseCluster(
         com.google.cloud.dataproc.v1.DiagnoseClusterRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDiagnoseClusterMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDiagnoseClusterMethod(), getCallOptions(), request);
     }
   }
 
@@ -784,11 +730,7 @@ public final class ClusterControllerGrpc {
    * </pre>
    */
   public static final class ClusterControllerFutureStub
-      extends io.grpc.stub.AbstractStub<ClusterControllerFutureStub> {
-    private ClusterControllerFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<ClusterControllerFutureStub> {
     private ClusterControllerFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -811,7 +753,7 @@ public final class ClusterControllerGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         createCluster(com.google.cloud.dataproc.v1.CreateClusterRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateClusterMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateClusterMethod(), getCallOptions()), request);
     }
 
     /**
@@ -826,7 +768,7 @@ public final class ClusterControllerGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         updateCluster(com.google.cloud.dataproc.v1.UpdateClusterRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateClusterMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateClusterMethod(), getCallOptions()), request);
     }
 
     /**
@@ -841,7 +783,7 @@ public final class ClusterControllerGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         deleteCluster(com.google.cloud.dataproc.v1.DeleteClusterRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteClusterMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteClusterMethod(), getCallOptions()), request);
     }
 
     /**
@@ -854,7 +796,7 @@ public final class ClusterControllerGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.dataproc.v1.Cluster>
         getCluster(com.google.cloud.dataproc.v1.GetClusterRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetClusterMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetClusterMethod(), getCallOptions()), request);
     }
 
     /**
@@ -868,7 +810,7 @@ public final class ClusterControllerGrpc {
             com.google.cloud.dataproc.v1.ListClustersResponse>
         listClusters(com.google.cloud.dataproc.v1.ListClustersRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListClustersMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListClustersMethod(), getCallOptions()), request);
     }
 
     /**
@@ -887,7 +829,7 @@ public final class ClusterControllerGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         diagnoseCluster(com.google.cloud.dataproc.v1.DiagnoseClusterRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDiagnoseClusterMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDiagnoseClusterMethod(), getCallOptions()), request);
     }
   }
 
@@ -1010,12 +952,12 @@ public final class ClusterControllerGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new ClusterControllerFileDescriptorSupplier())
-                      .addMethod(getCreateClusterMethodHelper())
-                      .addMethod(getUpdateClusterMethodHelper())
-                      .addMethod(getDeleteClusterMethodHelper())
-                      .addMethod(getGetClusterMethodHelper())
-                      .addMethod(getListClustersMethodHelper())
-                      .addMethod(getDiagnoseClusterMethodHelper())
+                      .addMethod(getCreateClusterMethod())
+                      .addMethod(getUpdateClusterMethod())
+                      .addMethod(getDeleteClusterMethod())
+                      .addMethod(getGetClusterMethod())
+                      .addMethod(getListClustersMethod())
+                      .addMethod(getDiagnoseClusterMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dataproc-v1/src/main/java/com/google/cloud/dataproc/v1/JobControllerGrpc.java
+++ b/grpc-google-cloud-dataproc-v1/src/main/java/com/google/cloud/dataproc/v1/JobControllerGrpc.java
@@ -30,7 +30,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dataproc/v1/jobs.proto")
 public final class JobControllerGrpc {
 
@@ -39,26 +39,18 @@ public final class JobControllerGrpc {
   public static final String SERVICE_NAME = "google.cloud.dataproc.v1.JobController";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSubmitJobMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.SubmitJobRequest, com.google.cloud.dataproc.v1.Job>
-      METHOD_SUBMIT_JOB = getSubmitJobMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.SubmitJobRequest, com.google.cloud.dataproc.v1.Job>
       getSubmitJobMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SubmitJob",
+      requestType = com.google.cloud.dataproc.v1.SubmitJobRequest.class,
+      responseType = com.google.cloud.dataproc.v1.Job.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.SubmitJobRequest, com.google.cloud.dataproc.v1.Job>
       getSubmitJobMethod() {
-    return getSubmitJobMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.SubmitJobRequest, com.google.cloud.dataproc.v1.Job>
-      getSubmitJobMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.SubmitJobRequest, com.google.cloud.dataproc.v1.Job>
         getSubmitJobMethod;
@@ -72,9 +64,7 @@ public final class JobControllerGrpc {
                           com.google.cloud.dataproc.v1.Job>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.JobController", "SubmitJob"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SubmitJob"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -90,26 +80,18 @@ public final class JobControllerGrpc {
     return getSubmitJobMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetJobMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.GetJobRequest, com.google.cloud.dataproc.v1.Job>
-      METHOD_GET_JOB = getGetJobMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.GetJobRequest, com.google.cloud.dataproc.v1.Job>
       getGetJobMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetJob",
+      requestType = com.google.cloud.dataproc.v1.GetJobRequest.class,
+      responseType = com.google.cloud.dataproc.v1.Job.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.GetJobRequest, com.google.cloud.dataproc.v1.Job>
       getGetJobMethod() {
-    return getGetJobMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.GetJobRequest, com.google.cloud.dataproc.v1.Job>
-      getGetJobMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.GetJobRequest, com.google.cloud.dataproc.v1.Job>
         getGetJobMethod;
@@ -123,9 +105,7 @@ public final class JobControllerGrpc {
                           com.google.cloud.dataproc.v1.Job>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.JobController", "GetJob"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetJob"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -141,30 +121,20 @@ public final class JobControllerGrpc {
     return getGetJobMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListJobsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.ListJobsRequest,
-          com.google.cloud.dataproc.v1.ListJobsResponse>
-      METHOD_LIST_JOBS = getListJobsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.ListJobsRequest,
           com.google.cloud.dataproc.v1.ListJobsResponse>
       getListJobsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListJobs",
+      requestType = com.google.cloud.dataproc.v1.ListJobsRequest.class,
+      responseType = com.google.cloud.dataproc.v1.ListJobsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.ListJobsRequest,
           com.google.cloud.dataproc.v1.ListJobsResponse>
       getListJobsMethod() {
-    return getListJobsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.ListJobsRequest,
-          com.google.cloud.dataproc.v1.ListJobsResponse>
-      getListJobsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.ListJobsRequest,
             com.google.cloud.dataproc.v1.ListJobsResponse>
@@ -179,9 +149,7 @@ public final class JobControllerGrpc {
                           com.google.cloud.dataproc.v1.ListJobsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.JobController", "ListJobs"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListJobs"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -197,26 +165,18 @@ public final class JobControllerGrpc {
     return getListJobsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateJobMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.UpdateJobRequest, com.google.cloud.dataproc.v1.Job>
-      METHOD_UPDATE_JOB = getUpdateJobMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.UpdateJobRequest, com.google.cloud.dataproc.v1.Job>
       getUpdateJobMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateJob",
+      requestType = com.google.cloud.dataproc.v1.UpdateJobRequest.class,
+      responseType = com.google.cloud.dataproc.v1.Job.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.UpdateJobRequest, com.google.cloud.dataproc.v1.Job>
       getUpdateJobMethod() {
-    return getUpdateJobMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.UpdateJobRequest, com.google.cloud.dataproc.v1.Job>
-      getUpdateJobMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.UpdateJobRequest, com.google.cloud.dataproc.v1.Job>
         getUpdateJobMethod;
@@ -230,9 +190,7 @@ public final class JobControllerGrpc {
                           com.google.cloud.dataproc.v1.Job>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.JobController", "UpdateJob"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateJob"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -248,26 +206,18 @@ public final class JobControllerGrpc {
     return getUpdateJobMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCancelJobMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.CancelJobRequest, com.google.cloud.dataproc.v1.Job>
-      METHOD_CANCEL_JOB = getCancelJobMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.CancelJobRequest, com.google.cloud.dataproc.v1.Job>
       getCancelJobMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CancelJob",
+      requestType = com.google.cloud.dataproc.v1.CancelJobRequest.class,
+      responseType = com.google.cloud.dataproc.v1.Job.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.CancelJobRequest, com.google.cloud.dataproc.v1.Job>
       getCancelJobMethod() {
-    return getCancelJobMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.CancelJobRequest, com.google.cloud.dataproc.v1.Job>
-      getCancelJobMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.CancelJobRequest, com.google.cloud.dataproc.v1.Job>
         getCancelJobMethod;
@@ -281,9 +231,7 @@ public final class JobControllerGrpc {
                           com.google.cloud.dataproc.v1.Job>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.JobController", "CancelJob"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CancelJob"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -299,26 +247,18 @@ public final class JobControllerGrpc {
     return getCancelJobMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteJobMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.DeleteJobRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_JOB = getDeleteJobMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.DeleteJobRequest, com.google.protobuf.Empty>
       getDeleteJobMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteJob",
+      requestType = com.google.cloud.dataproc.v1.DeleteJobRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.DeleteJobRequest, com.google.protobuf.Empty>
       getDeleteJobMethod() {
-    return getDeleteJobMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.DeleteJobRequest, com.google.protobuf.Empty>
-      getDeleteJobMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.DeleteJobRequest, com.google.protobuf.Empty>
         getDeleteJobMethod;
@@ -331,9 +271,7 @@ public final class JobControllerGrpc {
                       .<com.google.cloud.dataproc.v1.DeleteJobRequest, com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.JobController", "DeleteJob"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteJob"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -351,19 +289,43 @@ public final class JobControllerGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static JobControllerStub newStub(io.grpc.Channel channel) {
-    return new JobControllerStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<JobControllerStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<JobControllerStub>() {
+          @java.lang.Override
+          public JobControllerStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new JobControllerStub(channel, callOptions);
+          }
+        };
+    return JobControllerStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static JobControllerBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new JobControllerBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<JobControllerBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<JobControllerBlockingStub>() {
+          @java.lang.Override
+          public JobControllerBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new JobControllerBlockingStub(channel, callOptions);
+          }
+        };
+    return JobControllerBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static JobControllerFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new JobControllerFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<JobControllerFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<JobControllerFutureStub>() {
+          @java.lang.Override
+          public JobControllerFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new JobControllerFutureStub(channel, callOptions);
+          }
+        };
+    return JobControllerFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -385,7 +347,7 @@ public final class JobControllerGrpc {
     public void submitJob(
         com.google.cloud.dataproc.v1.SubmitJobRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.Job> responseObserver) {
-      asyncUnimplementedUnaryCall(getSubmitJobMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getSubmitJobMethod(), responseObserver);
     }
 
     /**
@@ -398,7 +360,7 @@ public final class JobControllerGrpc {
     public void getJob(
         com.google.cloud.dataproc.v1.GetJobRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.Job> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetJobMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetJobMethod(), responseObserver);
     }
 
     /**
@@ -412,7 +374,7 @@ public final class JobControllerGrpc {
         com.google.cloud.dataproc.v1.ListJobsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.ListJobsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListJobsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListJobsMethod(), responseObserver);
     }
 
     /**
@@ -425,7 +387,7 @@ public final class JobControllerGrpc {
     public void updateJob(
         com.google.cloud.dataproc.v1.UpdateJobRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.Job> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateJobMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateJobMethod(), responseObserver);
     }
 
     /**
@@ -442,7 +404,7 @@ public final class JobControllerGrpc {
     public void cancelJob(
         com.google.cloud.dataproc.v1.CancelJobRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.Job> responseObserver) {
-      asyncUnimplementedUnaryCall(getCancelJobMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCancelJobMethod(), responseObserver);
     }
 
     /**
@@ -456,44 +418,44 @@ public final class JobControllerGrpc {
     public void deleteJob(
         com.google.cloud.dataproc.v1.DeleteJobRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteJobMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteJobMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getSubmitJobMethodHelper(),
+              getSubmitJobMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.SubmitJobRequest,
                       com.google.cloud.dataproc.v1.Job>(this, METHODID_SUBMIT_JOB)))
           .addMethod(
-              getGetJobMethodHelper(),
+              getGetJobMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.GetJobRequest, com.google.cloud.dataproc.v1.Job>(
                       this, METHODID_GET_JOB)))
           .addMethod(
-              getListJobsMethodHelper(),
+              getListJobsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.ListJobsRequest,
                       com.google.cloud.dataproc.v1.ListJobsResponse>(this, METHODID_LIST_JOBS)))
           .addMethod(
-              getUpdateJobMethodHelper(),
+              getUpdateJobMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.UpdateJobRequest,
                       com.google.cloud.dataproc.v1.Job>(this, METHODID_UPDATE_JOB)))
           .addMethod(
-              getCancelJobMethodHelper(),
+              getCancelJobMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.CancelJobRequest,
                       com.google.cloud.dataproc.v1.Job>(this, METHODID_CANCEL_JOB)))
           .addMethod(
-              getDeleteJobMethodHelper(),
+              getDeleteJobMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.DeleteJobRequest, com.google.protobuf.Empty>(
@@ -509,11 +471,8 @@ public final class JobControllerGrpc {
    * The JobController provides methods to manage jobs.
    * </pre>
    */
-  public static final class JobControllerStub extends io.grpc.stub.AbstractStub<JobControllerStub> {
-    private JobControllerStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class JobControllerStub
+      extends io.grpc.stub.AbstractAsyncStub<JobControllerStub> {
     private JobControllerStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -534,9 +493,7 @@ public final class JobControllerGrpc {
         com.google.cloud.dataproc.v1.SubmitJobRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.Job> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getSubmitJobMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getSubmitJobMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -550,9 +507,7 @@ public final class JobControllerGrpc {
         com.google.cloud.dataproc.v1.GetJobRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.Job> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetJobMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetJobMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -567,9 +522,7 @@ public final class JobControllerGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.ListJobsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListJobsMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getListJobsMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -583,9 +536,7 @@ public final class JobControllerGrpc {
         com.google.cloud.dataproc.v1.UpdateJobRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.Job> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateJobMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getUpdateJobMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -603,9 +554,7 @@ public final class JobControllerGrpc {
         com.google.cloud.dataproc.v1.CancelJobRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.Job> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCancelJobMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getCancelJobMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -620,9 +569,7 @@ public final class JobControllerGrpc {
         com.google.cloud.dataproc.v1.DeleteJobRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteJobMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getDeleteJobMethod(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -634,11 +581,7 @@ public final class JobControllerGrpc {
    * </pre>
    */
   public static final class JobControllerBlockingStub
-      extends io.grpc.stub.AbstractStub<JobControllerBlockingStub> {
-    private JobControllerBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<JobControllerBlockingStub> {
     private JobControllerBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -658,7 +601,7 @@ public final class JobControllerGrpc {
      */
     public com.google.cloud.dataproc.v1.Job submitJob(
         com.google.cloud.dataproc.v1.SubmitJobRequest request) {
-      return blockingUnaryCall(getChannel(), getSubmitJobMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getSubmitJobMethod(), getCallOptions(), request);
     }
 
     /**
@@ -670,7 +613,7 @@ public final class JobControllerGrpc {
      */
     public com.google.cloud.dataproc.v1.Job getJob(
         com.google.cloud.dataproc.v1.GetJobRequest request) {
-      return blockingUnaryCall(getChannel(), getGetJobMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetJobMethod(), getCallOptions(), request);
     }
 
     /**
@@ -682,7 +625,7 @@ public final class JobControllerGrpc {
      */
     public com.google.cloud.dataproc.v1.ListJobsResponse listJobs(
         com.google.cloud.dataproc.v1.ListJobsRequest request) {
-      return blockingUnaryCall(getChannel(), getListJobsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListJobsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -694,7 +637,7 @@ public final class JobControllerGrpc {
      */
     public com.google.cloud.dataproc.v1.Job updateJob(
         com.google.cloud.dataproc.v1.UpdateJobRequest request) {
-      return blockingUnaryCall(getChannel(), getUpdateJobMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateJobMethod(), getCallOptions(), request);
     }
 
     /**
@@ -710,7 +653,7 @@ public final class JobControllerGrpc {
      */
     public com.google.cloud.dataproc.v1.Job cancelJob(
         com.google.cloud.dataproc.v1.CancelJobRequest request) {
-      return blockingUnaryCall(getChannel(), getCancelJobMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCancelJobMethod(), getCallOptions(), request);
     }
 
     /**
@@ -723,7 +666,7 @@ public final class JobControllerGrpc {
      */
     public com.google.protobuf.Empty deleteJob(
         com.google.cloud.dataproc.v1.DeleteJobRequest request) {
-      return blockingUnaryCall(getChannel(), getDeleteJobMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteJobMethod(), getCallOptions(), request);
     }
   }
 
@@ -735,11 +678,7 @@ public final class JobControllerGrpc {
    * </pre>
    */
   public static final class JobControllerFutureStub
-      extends io.grpc.stub.AbstractStub<JobControllerFutureStub> {
-    private JobControllerFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<JobControllerFutureStub> {
     private JobControllerFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -759,8 +698,7 @@ public final class JobControllerGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.dataproc.v1.Job>
         submitJob(com.google.cloud.dataproc.v1.SubmitJobRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getSubmitJobMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getSubmitJobMethod(), getCallOptions()), request);
     }
 
     /**
@@ -772,8 +710,7 @@ public final class JobControllerGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.dataproc.v1.Job>
         getJob(com.google.cloud.dataproc.v1.GetJobRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getGetJobMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getGetJobMethod(), getCallOptions()), request);
     }
 
     /**
@@ -786,8 +723,7 @@ public final class JobControllerGrpc {
     public com.google.common.util.concurrent.ListenableFuture<
             com.google.cloud.dataproc.v1.ListJobsResponse>
         listJobs(com.google.cloud.dataproc.v1.ListJobsRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getListJobsMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getListJobsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -799,8 +735,7 @@ public final class JobControllerGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.dataproc.v1.Job>
         updateJob(com.google.cloud.dataproc.v1.UpdateJobRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getUpdateJobMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getUpdateJobMethod(), getCallOptions()), request);
     }
 
     /**
@@ -816,8 +751,7 @@ public final class JobControllerGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.dataproc.v1.Job>
         cancelJob(com.google.cloud.dataproc.v1.CancelJobRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getCancelJobMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getCancelJobMethod(), getCallOptions()), request);
     }
 
     /**
@@ -830,8 +764,7 @@ public final class JobControllerGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> deleteJob(
         com.google.cloud.dataproc.v1.DeleteJobRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getDeleteJobMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getDeleteJobMethod(), getCallOptions()), request);
     }
   }
 
@@ -954,12 +887,12 @@ public final class JobControllerGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new JobControllerFileDescriptorSupplier())
-                      .addMethod(getSubmitJobMethodHelper())
-                      .addMethod(getGetJobMethodHelper())
-                      .addMethod(getListJobsMethodHelper())
-                      .addMethod(getUpdateJobMethodHelper())
-                      .addMethod(getCancelJobMethodHelper())
-                      .addMethod(getDeleteJobMethodHelper())
+                      .addMethod(getSubmitJobMethod())
+                      .addMethod(getGetJobMethod())
+                      .addMethod(getListJobsMethod())
+                      .addMethod(getUpdateJobMethod())
+                      .addMethod(getCancelJobMethod())
+                      .addMethod(getDeleteJobMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dataproc-v1/src/main/java/com/google/cloud/dataproc/v1/WorkflowTemplateServiceGrpc.java
+++ b/grpc-google-cloud-dataproc-v1/src/main/java/com/google/cloud/dataproc/v1/WorkflowTemplateServiceGrpc.java
@@ -31,7 +31,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dataproc/v1/workflow_templates.proto")
 public final class WorkflowTemplateServiceGrpc {
 
@@ -40,30 +40,20 @@ public final class WorkflowTemplateServiceGrpc {
   public static final String SERVICE_NAME = "google.cloud.dataproc.v1.WorkflowTemplateService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateWorkflowTemplateMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.CreateWorkflowTemplateRequest,
-          com.google.cloud.dataproc.v1.WorkflowTemplate>
-      METHOD_CREATE_WORKFLOW_TEMPLATE = getCreateWorkflowTemplateMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.CreateWorkflowTemplateRequest,
           com.google.cloud.dataproc.v1.WorkflowTemplate>
       getCreateWorkflowTemplateMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateWorkflowTemplate",
+      requestType = com.google.cloud.dataproc.v1.CreateWorkflowTemplateRequest.class,
+      responseType = com.google.cloud.dataproc.v1.WorkflowTemplate.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.CreateWorkflowTemplateRequest,
           com.google.cloud.dataproc.v1.WorkflowTemplate>
       getCreateWorkflowTemplateMethod() {
-    return getCreateWorkflowTemplateMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.CreateWorkflowTemplateRequest,
-          com.google.cloud.dataproc.v1.WorkflowTemplate>
-      getCreateWorkflowTemplateMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.CreateWorkflowTemplateRequest,
             com.google.cloud.dataproc.v1.WorkflowTemplate>
@@ -83,9 +73,7 @@ public final class WorkflowTemplateServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.WorkflowTemplateService",
-                              "CreateWorkflowTemplate"))
+                          generateFullMethodName(SERVICE_NAME, "CreateWorkflowTemplate"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -104,30 +92,20 @@ public final class WorkflowTemplateServiceGrpc {
     return getCreateWorkflowTemplateMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetWorkflowTemplateMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.GetWorkflowTemplateRequest,
-          com.google.cloud.dataproc.v1.WorkflowTemplate>
-      METHOD_GET_WORKFLOW_TEMPLATE = getGetWorkflowTemplateMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.GetWorkflowTemplateRequest,
           com.google.cloud.dataproc.v1.WorkflowTemplate>
       getGetWorkflowTemplateMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetWorkflowTemplate",
+      requestType = com.google.cloud.dataproc.v1.GetWorkflowTemplateRequest.class,
+      responseType = com.google.cloud.dataproc.v1.WorkflowTemplate.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.GetWorkflowTemplateRequest,
           com.google.cloud.dataproc.v1.WorkflowTemplate>
       getGetWorkflowTemplateMethod() {
-    return getGetWorkflowTemplateMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.GetWorkflowTemplateRequest,
-          com.google.cloud.dataproc.v1.WorkflowTemplate>
-      getGetWorkflowTemplateMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.GetWorkflowTemplateRequest,
             com.google.cloud.dataproc.v1.WorkflowTemplate>
@@ -146,9 +124,7 @@ public final class WorkflowTemplateServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.WorkflowTemplateService",
-                              "GetWorkflowTemplate"))
+                          generateFullMethodName(SERVICE_NAME, "GetWorkflowTemplate"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -167,30 +143,20 @@ public final class WorkflowTemplateServiceGrpc {
     return getGetWorkflowTemplateMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getInstantiateWorkflowTemplateMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.InstantiateWorkflowTemplateRequest,
-          com.google.longrunning.Operation>
-      METHOD_INSTANTIATE_WORKFLOW_TEMPLATE = getInstantiateWorkflowTemplateMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.InstantiateWorkflowTemplateRequest,
           com.google.longrunning.Operation>
       getInstantiateWorkflowTemplateMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "InstantiateWorkflowTemplate",
+      requestType = com.google.cloud.dataproc.v1.InstantiateWorkflowTemplateRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.InstantiateWorkflowTemplateRequest,
           com.google.longrunning.Operation>
       getInstantiateWorkflowTemplateMethod() {
-    return getInstantiateWorkflowTemplateMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.InstantiateWorkflowTemplateRequest,
-          com.google.longrunning.Operation>
-      getInstantiateWorkflowTemplateMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.InstantiateWorkflowTemplateRequest,
             com.google.longrunning.Operation>
@@ -210,9 +176,7 @@ public final class WorkflowTemplateServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.WorkflowTemplateService",
-                              "InstantiateWorkflowTemplate"))
+                          generateFullMethodName(SERVICE_NAME, "InstantiateWorkflowTemplate"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -231,31 +195,20 @@ public final class WorkflowTemplateServiceGrpc {
     return getInstantiateWorkflowTemplateMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getInstantiateInlineWorkflowTemplateMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.InstantiateInlineWorkflowTemplateRequest,
-          com.google.longrunning.Operation>
-      METHOD_INSTANTIATE_INLINE_WORKFLOW_TEMPLATE =
-          getInstantiateInlineWorkflowTemplateMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.InstantiateInlineWorkflowTemplateRequest,
           com.google.longrunning.Operation>
       getInstantiateInlineWorkflowTemplateMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "InstantiateInlineWorkflowTemplate",
+      requestType = com.google.cloud.dataproc.v1.InstantiateInlineWorkflowTemplateRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.InstantiateInlineWorkflowTemplateRequest,
           com.google.longrunning.Operation>
       getInstantiateInlineWorkflowTemplateMethod() {
-    return getInstantiateInlineWorkflowTemplateMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.InstantiateInlineWorkflowTemplateRequest,
-          com.google.longrunning.Operation>
-      getInstantiateInlineWorkflowTemplateMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.InstantiateInlineWorkflowTemplateRequest,
             com.google.longrunning.Operation>
@@ -275,9 +228,7 @@ public final class WorkflowTemplateServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.WorkflowTemplateService",
-                              "InstantiateInlineWorkflowTemplate"))
+                          generateFullMethodName(SERVICE_NAME, "InstantiateInlineWorkflowTemplate"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -296,30 +247,20 @@ public final class WorkflowTemplateServiceGrpc {
     return getInstantiateInlineWorkflowTemplateMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateWorkflowTemplateMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.UpdateWorkflowTemplateRequest,
-          com.google.cloud.dataproc.v1.WorkflowTemplate>
-      METHOD_UPDATE_WORKFLOW_TEMPLATE = getUpdateWorkflowTemplateMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.UpdateWorkflowTemplateRequest,
           com.google.cloud.dataproc.v1.WorkflowTemplate>
       getUpdateWorkflowTemplateMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateWorkflowTemplate",
+      requestType = com.google.cloud.dataproc.v1.UpdateWorkflowTemplateRequest.class,
+      responseType = com.google.cloud.dataproc.v1.WorkflowTemplate.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.UpdateWorkflowTemplateRequest,
           com.google.cloud.dataproc.v1.WorkflowTemplate>
       getUpdateWorkflowTemplateMethod() {
-    return getUpdateWorkflowTemplateMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.UpdateWorkflowTemplateRequest,
-          com.google.cloud.dataproc.v1.WorkflowTemplate>
-      getUpdateWorkflowTemplateMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.UpdateWorkflowTemplateRequest,
             com.google.cloud.dataproc.v1.WorkflowTemplate>
@@ -339,9 +280,7 @@ public final class WorkflowTemplateServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.WorkflowTemplateService",
-                              "UpdateWorkflowTemplate"))
+                          generateFullMethodName(SERVICE_NAME, "UpdateWorkflowTemplate"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -360,30 +299,20 @@ public final class WorkflowTemplateServiceGrpc {
     return getUpdateWorkflowTemplateMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListWorkflowTemplatesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.ListWorkflowTemplatesRequest,
-          com.google.cloud.dataproc.v1.ListWorkflowTemplatesResponse>
-      METHOD_LIST_WORKFLOW_TEMPLATES = getListWorkflowTemplatesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.ListWorkflowTemplatesRequest,
           com.google.cloud.dataproc.v1.ListWorkflowTemplatesResponse>
       getListWorkflowTemplatesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListWorkflowTemplates",
+      requestType = com.google.cloud.dataproc.v1.ListWorkflowTemplatesRequest.class,
+      responseType = com.google.cloud.dataproc.v1.ListWorkflowTemplatesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.ListWorkflowTemplatesRequest,
           com.google.cloud.dataproc.v1.ListWorkflowTemplatesResponse>
       getListWorkflowTemplatesMethod() {
-    return getListWorkflowTemplatesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.ListWorkflowTemplatesRequest,
-          com.google.cloud.dataproc.v1.ListWorkflowTemplatesResponse>
-      getListWorkflowTemplatesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.ListWorkflowTemplatesRequest,
             com.google.cloud.dataproc.v1.ListWorkflowTemplatesResponse>
@@ -403,9 +332,7 @@ public final class WorkflowTemplateServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.WorkflowTemplateService",
-                              "ListWorkflowTemplates"))
+                          generateFullMethodName(SERVICE_NAME, "ListWorkflowTemplates"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -425,26 +352,18 @@ public final class WorkflowTemplateServiceGrpc {
     return getListWorkflowTemplatesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteWorkflowTemplateMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.DeleteWorkflowTemplateRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_WORKFLOW_TEMPLATE = getDeleteWorkflowTemplateMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.DeleteWorkflowTemplateRequest, com.google.protobuf.Empty>
       getDeleteWorkflowTemplateMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteWorkflowTemplate",
+      requestType = com.google.cloud.dataproc.v1.DeleteWorkflowTemplateRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1.DeleteWorkflowTemplateRequest, com.google.protobuf.Empty>
       getDeleteWorkflowTemplateMethod() {
-    return getDeleteWorkflowTemplateMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1.DeleteWorkflowTemplateRequest, com.google.protobuf.Empty>
-      getDeleteWorkflowTemplateMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1.DeleteWorkflowTemplateRequest, com.google.protobuf.Empty>
         getDeleteWorkflowTemplateMethod;
@@ -463,9 +382,7 @@ public final class WorkflowTemplateServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1.WorkflowTemplateService",
-                              "DeleteWorkflowTemplate"))
+                          generateFullMethodName(SERVICE_NAME, "DeleteWorkflowTemplate"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -486,19 +403,43 @@ public final class WorkflowTemplateServiceGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static WorkflowTemplateServiceStub newStub(io.grpc.Channel channel) {
-    return new WorkflowTemplateServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<WorkflowTemplateServiceStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<WorkflowTemplateServiceStub>() {
+          @java.lang.Override
+          public WorkflowTemplateServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new WorkflowTemplateServiceStub(channel, callOptions);
+          }
+        };
+    return WorkflowTemplateServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static WorkflowTemplateServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new WorkflowTemplateServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<WorkflowTemplateServiceBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<WorkflowTemplateServiceBlockingStub>() {
+          @java.lang.Override
+          public WorkflowTemplateServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new WorkflowTemplateServiceBlockingStub(channel, callOptions);
+          }
+        };
+    return WorkflowTemplateServiceBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static WorkflowTemplateServiceFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new WorkflowTemplateServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<WorkflowTemplateServiceFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<WorkflowTemplateServiceFutureStub>() {
+          @java.lang.Override
+          public WorkflowTemplateServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new WorkflowTemplateServiceFutureStub(channel, callOptions);
+          }
+        };
+    return WorkflowTemplateServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -522,7 +463,7 @@ public final class WorkflowTemplateServiceGrpc {
         com.google.cloud.dataproc.v1.CreateWorkflowTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.WorkflowTemplate>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateWorkflowTemplateMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateWorkflowTemplateMethod(), responseObserver);
     }
 
     /**
@@ -538,7 +479,7 @@ public final class WorkflowTemplateServiceGrpc {
         com.google.cloud.dataproc.v1.GetWorkflowTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.WorkflowTemplate>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetWorkflowTemplateMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetWorkflowTemplateMethod(), responseObserver);
     }
 
     /**
@@ -566,7 +507,7 @@ public final class WorkflowTemplateServiceGrpc {
     public void instantiateWorkflowTemplate(
         com.google.cloud.dataproc.v1.InstantiateWorkflowTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getInstantiateWorkflowTemplateMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getInstantiateWorkflowTemplateMethod(), responseObserver);
     }
 
     /**
@@ -597,8 +538,7 @@ public final class WorkflowTemplateServiceGrpc {
     public void instantiateInlineWorkflowTemplate(
         com.google.cloud.dataproc.v1.InstantiateInlineWorkflowTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(
-          getInstantiateInlineWorkflowTemplateMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getInstantiateInlineWorkflowTemplateMethod(), responseObserver);
     }
 
     /**
@@ -613,7 +553,7 @@ public final class WorkflowTemplateServiceGrpc {
         com.google.cloud.dataproc.v1.UpdateWorkflowTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.WorkflowTemplate>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateWorkflowTemplateMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateWorkflowTemplateMethod(), responseObserver);
     }
 
     /**
@@ -627,7 +567,7 @@ public final class WorkflowTemplateServiceGrpc {
         com.google.cloud.dataproc.v1.ListWorkflowTemplatesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.ListWorkflowTemplatesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListWorkflowTemplatesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListWorkflowTemplatesMethod(), responseObserver);
     }
 
     /**
@@ -640,56 +580,56 @@ public final class WorkflowTemplateServiceGrpc {
     public void deleteWorkflowTemplate(
         com.google.cloud.dataproc.v1.DeleteWorkflowTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteWorkflowTemplateMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteWorkflowTemplateMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getCreateWorkflowTemplateMethodHelper(),
+              getCreateWorkflowTemplateMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.CreateWorkflowTemplateRequest,
                       com.google.cloud.dataproc.v1.WorkflowTemplate>(
                       this, METHODID_CREATE_WORKFLOW_TEMPLATE)))
           .addMethod(
-              getGetWorkflowTemplateMethodHelper(),
+              getGetWorkflowTemplateMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.GetWorkflowTemplateRequest,
                       com.google.cloud.dataproc.v1.WorkflowTemplate>(
                       this, METHODID_GET_WORKFLOW_TEMPLATE)))
           .addMethod(
-              getInstantiateWorkflowTemplateMethodHelper(),
+              getInstantiateWorkflowTemplateMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.InstantiateWorkflowTemplateRequest,
                       com.google.longrunning.Operation>(
                       this, METHODID_INSTANTIATE_WORKFLOW_TEMPLATE)))
           .addMethod(
-              getInstantiateInlineWorkflowTemplateMethodHelper(),
+              getInstantiateInlineWorkflowTemplateMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.InstantiateInlineWorkflowTemplateRequest,
                       com.google.longrunning.Operation>(
                       this, METHODID_INSTANTIATE_INLINE_WORKFLOW_TEMPLATE)))
           .addMethod(
-              getUpdateWorkflowTemplateMethodHelper(),
+              getUpdateWorkflowTemplateMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.UpdateWorkflowTemplateRequest,
                       com.google.cloud.dataproc.v1.WorkflowTemplate>(
                       this, METHODID_UPDATE_WORKFLOW_TEMPLATE)))
           .addMethod(
-              getListWorkflowTemplatesMethodHelper(),
+              getListWorkflowTemplatesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.ListWorkflowTemplatesRequest,
                       com.google.cloud.dataproc.v1.ListWorkflowTemplatesResponse>(
                       this, METHODID_LIST_WORKFLOW_TEMPLATES)))
           .addMethod(
-              getDeleteWorkflowTemplateMethodHelper(),
+              getDeleteWorkflowTemplateMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1.DeleteWorkflowTemplateRequest,
@@ -707,11 +647,7 @@ public final class WorkflowTemplateServiceGrpc {
    * </pre>
    */
   public static final class WorkflowTemplateServiceStub
-      extends io.grpc.stub.AbstractStub<WorkflowTemplateServiceStub> {
-    private WorkflowTemplateServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<WorkflowTemplateServiceStub> {
     private WorkflowTemplateServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -734,7 +670,7 @@ public final class WorkflowTemplateServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.WorkflowTemplate>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateWorkflowTemplateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateWorkflowTemplateMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -753,7 +689,7 @@ public final class WorkflowTemplateServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.WorkflowTemplate>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetWorkflowTemplateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetWorkflowTemplateMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -784,7 +720,7 @@ public final class WorkflowTemplateServiceGrpc {
         com.google.cloud.dataproc.v1.InstantiateWorkflowTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getInstantiateWorkflowTemplateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getInstantiateWorkflowTemplateMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -818,8 +754,7 @@ public final class WorkflowTemplateServiceGrpc {
         com.google.cloud.dataproc.v1.InstantiateInlineWorkflowTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel()
-              .newCall(getInstantiateInlineWorkflowTemplateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getInstantiateInlineWorkflowTemplateMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -837,7 +772,7 @@ public final class WorkflowTemplateServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.WorkflowTemplate>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateWorkflowTemplateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateWorkflowTemplateMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -854,7 +789,7 @@ public final class WorkflowTemplateServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1.ListWorkflowTemplatesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListWorkflowTemplatesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListWorkflowTemplatesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -870,7 +805,7 @@ public final class WorkflowTemplateServiceGrpc {
         com.google.cloud.dataproc.v1.DeleteWorkflowTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteWorkflowTemplateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteWorkflowTemplateMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -885,11 +820,7 @@ public final class WorkflowTemplateServiceGrpc {
    * </pre>
    */
   public static final class WorkflowTemplateServiceBlockingStub
-      extends io.grpc.stub.AbstractStub<WorkflowTemplateServiceBlockingStub> {
-    private WorkflowTemplateServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<WorkflowTemplateServiceBlockingStub> {
     private WorkflowTemplateServiceBlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -911,7 +842,7 @@ public final class WorkflowTemplateServiceGrpc {
     public com.google.cloud.dataproc.v1.WorkflowTemplate createWorkflowTemplate(
         com.google.cloud.dataproc.v1.CreateWorkflowTemplateRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateWorkflowTemplateMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateWorkflowTemplateMethod(), getCallOptions(), request);
     }
 
     /**
@@ -926,7 +857,7 @@ public final class WorkflowTemplateServiceGrpc {
     public com.google.cloud.dataproc.v1.WorkflowTemplate getWorkflowTemplate(
         com.google.cloud.dataproc.v1.GetWorkflowTemplateRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetWorkflowTemplateMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetWorkflowTemplateMethod(), getCallOptions(), request);
     }
 
     /**
@@ -954,7 +885,7 @@ public final class WorkflowTemplateServiceGrpc {
     public com.google.longrunning.Operation instantiateWorkflowTemplate(
         com.google.cloud.dataproc.v1.InstantiateWorkflowTemplateRequest request) {
       return blockingUnaryCall(
-          getChannel(), getInstantiateWorkflowTemplateMethodHelper(), getCallOptions(), request);
+          getChannel(), getInstantiateWorkflowTemplateMethod(), getCallOptions(), request);
     }
 
     /**
@@ -985,10 +916,7 @@ public final class WorkflowTemplateServiceGrpc {
     public com.google.longrunning.Operation instantiateInlineWorkflowTemplate(
         com.google.cloud.dataproc.v1.InstantiateInlineWorkflowTemplateRequest request) {
       return blockingUnaryCall(
-          getChannel(),
-          getInstantiateInlineWorkflowTemplateMethodHelper(),
-          getCallOptions(),
-          request);
+          getChannel(), getInstantiateInlineWorkflowTemplateMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1002,7 +930,7 @@ public final class WorkflowTemplateServiceGrpc {
     public com.google.cloud.dataproc.v1.WorkflowTemplate updateWorkflowTemplate(
         com.google.cloud.dataproc.v1.UpdateWorkflowTemplateRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateWorkflowTemplateMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateWorkflowTemplateMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1015,7 +943,7 @@ public final class WorkflowTemplateServiceGrpc {
     public com.google.cloud.dataproc.v1.ListWorkflowTemplatesResponse listWorkflowTemplates(
         com.google.cloud.dataproc.v1.ListWorkflowTemplatesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListWorkflowTemplatesMethodHelper(), getCallOptions(), request);
+          getChannel(), getListWorkflowTemplatesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1028,7 +956,7 @@ public final class WorkflowTemplateServiceGrpc {
     public com.google.protobuf.Empty deleteWorkflowTemplate(
         com.google.cloud.dataproc.v1.DeleteWorkflowTemplateRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteWorkflowTemplateMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteWorkflowTemplateMethod(), getCallOptions(), request);
     }
   }
 
@@ -1041,11 +969,7 @@ public final class WorkflowTemplateServiceGrpc {
    * </pre>
    */
   public static final class WorkflowTemplateServiceFutureStub
-      extends io.grpc.stub.AbstractStub<WorkflowTemplateServiceFutureStub> {
-    private WorkflowTemplateServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<WorkflowTemplateServiceFutureStub> {
     private WorkflowTemplateServiceFutureStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -1068,7 +992,7 @@ public final class WorkflowTemplateServiceGrpc {
             com.google.cloud.dataproc.v1.WorkflowTemplate>
         createWorkflowTemplate(com.google.cloud.dataproc.v1.CreateWorkflowTemplateRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateWorkflowTemplateMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateWorkflowTemplateMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1084,7 +1008,7 @@ public final class WorkflowTemplateServiceGrpc {
             com.google.cloud.dataproc.v1.WorkflowTemplate>
         getWorkflowTemplate(com.google.cloud.dataproc.v1.GetWorkflowTemplateRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetWorkflowTemplateMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetWorkflowTemplateMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1113,8 +1037,7 @@ public final class WorkflowTemplateServiceGrpc {
         instantiateWorkflowTemplate(
             com.google.cloud.dataproc.v1.InstantiateWorkflowTemplateRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getInstantiateWorkflowTemplateMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getInstantiateWorkflowTemplateMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1146,8 +1069,7 @@ public final class WorkflowTemplateServiceGrpc {
         instantiateInlineWorkflowTemplate(
             com.google.cloud.dataproc.v1.InstantiateInlineWorkflowTemplateRequest request) {
       return futureUnaryCall(
-          getChannel()
-              .newCall(getInstantiateInlineWorkflowTemplateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getInstantiateInlineWorkflowTemplateMethod(), getCallOptions()),
           request);
     }
 
@@ -1163,7 +1085,7 @@ public final class WorkflowTemplateServiceGrpc {
             com.google.cloud.dataproc.v1.WorkflowTemplate>
         updateWorkflowTemplate(com.google.cloud.dataproc.v1.UpdateWorkflowTemplateRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateWorkflowTemplateMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateWorkflowTemplateMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1177,7 +1099,7 @@ public final class WorkflowTemplateServiceGrpc {
             com.google.cloud.dataproc.v1.ListWorkflowTemplatesResponse>
         listWorkflowTemplates(com.google.cloud.dataproc.v1.ListWorkflowTemplatesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListWorkflowTemplatesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListWorkflowTemplatesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1190,7 +1112,7 @@ public final class WorkflowTemplateServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty>
         deleteWorkflowTemplate(com.google.cloud.dataproc.v1.DeleteWorkflowTemplateRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteWorkflowTemplateMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteWorkflowTemplateMethod(), getCallOptions()), request);
     }
   }
 
@@ -1323,13 +1245,13 @@ public final class WorkflowTemplateServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new WorkflowTemplateServiceFileDescriptorSupplier())
-                      .addMethod(getCreateWorkflowTemplateMethodHelper())
-                      .addMethod(getGetWorkflowTemplateMethodHelper())
-                      .addMethod(getInstantiateWorkflowTemplateMethodHelper())
-                      .addMethod(getInstantiateInlineWorkflowTemplateMethodHelper())
-                      .addMethod(getUpdateWorkflowTemplateMethodHelper())
-                      .addMethod(getListWorkflowTemplatesMethodHelper())
-                      .addMethod(getDeleteWorkflowTemplateMethodHelper())
+                      .addMethod(getCreateWorkflowTemplateMethod())
+                      .addMethod(getGetWorkflowTemplateMethod())
+                      .addMethod(getInstantiateWorkflowTemplateMethod())
+                      .addMethod(getInstantiateInlineWorkflowTemplateMethod())
+                      .addMethod(getUpdateWorkflowTemplateMethod())
+                      .addMethod(getListWorkflowTemplatesMethod())
+                      .addMethod(getDeleteWorkflowTemplateMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dataproc-v1beta2/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-dataproc-v1beta2/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 0.120.1 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/dataproc/v1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-dataproc-v1beta2/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-dataproc-v1beta2/clirr-ignored-differences.xml
@@ -4,7 +4,7 @@
   <difference>
     <!-- TODO: remove after 0.120.1 released -->
     <differenceType>6001</differenceType>
-    <className>com/google/cloud/dataproc/v1/*Grpc</className>
+    <className>com/google/cloud/dataproc/v1beta2/*Grpc</className>
     <field>METHOD_*</field>
   </difference>
 </differences>

--- a/grpc-google-cloud-dataproc-v1beta2/src/main/java/com/google/cloud/dataproc/v1beta2/AutoscalingPolicyServiceGrpc.java
+++ b/grpc-google-cloud-dataproc-v1beta2/src/main/java/com/google/cloud/dataproc/v1beta2/AutoscalingPolicyServiceGrpc.java
@@ -31,7 +31,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dataproc/v1beta2/autoscaling_policies.proto")
 public final class AutoscalingPolicyServiceGrpc {
 
@@ -41,30 +41,20 @@ public final class AutoscalingPolicyServiceGrpc {
       "google.cloud.dataproc.v1beta2.AutoscalingPolicyService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateAutoscalingPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.CreateAutoscalingPolicyRequest,
-          com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
-      METHOD_CREATE_AUTOSCALING_POLICY = getCreateAutoscalingPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.CreateAutoscalingPolicyRequest,
           com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
       getCreateAutoscalingPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateAutoscalingPolicy",
+      requestType = com.google.cloud.dataproc.v1beta2.CreateAutoscalingPolicyRequest.class,
+      responseType = com.google.cloud.dataproc.v1beta2.AutoscalingPolicy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.CreateAutoscalingPolicyRequest,
           com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
       getCreateAutoscalingPolicyMethod() {
-    return getCreateAutoscalingPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.CreateAutoscalingPolicyRequest,
-          com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
-      getCreateAutoscalingPolicyMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.CreateAutoscalingPolicyRequest,
             com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
@@ -84,9 +74,7 @@ public final class AutoscalingPolicyServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.AutoscalingPolicyService",
-                              "CreateAutoscalingPolicy"))
+                          generateFullMethodName(SERVICE_NAME, "CreateAutoscalingPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -106,30 +94,20 @@ public final class AutoscalingPolicyServiceGrpc {
     return getCreateAutoscalingPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateAutoscalingPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.UpdateAutoscalingPolicyRequest,
-          com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
-      METHOD_UPDATE_AUTOSCALING_POLICY = getUpdateAutoscalingPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.UpdateAutoscalingPolicyRequest,
           com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
       getUpdateAutoscalingPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateAutoscalingPolicy",
+      requestType = com.google.cloud.dataproc.v1beta2.UpdateAutoscalingPolicyRequest.class,
+      responseType = com.google.cloud.dataproc.v1beta2.AutoscalingPolicy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.UpdateAutoscalingPolicyRequest,
           com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
       getUpdateAutoscalingPolicyMethod() {
-    return getUpdateAutoscalingPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.UpdateAutoscalingPolicyRequest,
-          com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
-      getUpdateAutoscalingPolicyMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.UpdateAutoscalingPolicyRequest,
             com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
@@ -149,9 +127,7 @@ public final class AutoscalingPolicyServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.AutoscalingPolicyService",
-                              "UpdateAutoscalingPolicy"))
+                          generateFullMethodName(SERVICE_NAME, "UpdateAutoscalingPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -171,30 +147,20 @@ public final class AutoscalingPolicyServiceGrpc {
     return getUpdateAutoscalingPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetAutoscalingPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.GetAutoscalingPolicyRequest,
-          com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
-      METHOD_GET_AUTOSCALING_POLICY = getGetAutoscalingPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.GetAutoscalingPolicyRequest,
           com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
       getGetAutoscalingPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetAutoscalingPolicy",
+      requestType = com.google.cloud.dataproc.v1beta2.GetAutoscalingPolicyRequest.class,
+      responseType = com.google.cloud.dataproc.v1beta2.AutoscalingPolicy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.GetAutoscalingPolicyRequest,
           com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
       getGetAutoscalingPolicyMethod() {
-    return getGetAutoscalingPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.GetAutoscalingPolicyRequest,
-          com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
-      getGetAutoscalingPolicyMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.GetAutoscalingPolicyRequest,
             com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
@@ -213,9 +179,7 @@ public final class AutoscalingPolicyServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.AutoscalingPolicyService",
-                              "GetAutoscalingPolicy"))
+                          generateFullMethodName(SERVICE_NAME, "GetAutoscalingPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -235,30 +199,20 @@ public final class AutoscalingPolicyServiceGrpc {
     return getGetAutoscalingPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListAutoscalingPoliciesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesRequest,
-          com.google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesResponse>
-      METHOD_LIST_AUTOSCALING_POLICIES = getListAutoscalingPoliciesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesRequest,
           com.google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesResponse>
       getListAutoscalingPoliciesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListAutoscalingPolicies",
+      requestType = com.google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesRequest.class,
+      responseType = com.google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesRequest,
           com.google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesResponse>
       getListAutoscalingPoliciesMethod() {
-    return getListAutoscalingPoliciesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesRequest,
-          com.google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesResponse>
-      getListAutoscalingPoliciesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesRequest,
             com.google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesResponse>
@@ -278,9 +232,7 @@ public final class AutoscalingPolicyServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.AutoscalingPolicyService",
-                              "ListAutoscalingPolicies"))
+                          generateFullMethodName(SERVICE_NAME, "ListAutoscalingPolicies"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -300,30 +252,20 @@ public final class AutoscalingPolicyServiceGrpc {
     return getListAutoscalingPoliciesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteAutoscalingPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.DeleteAutoscalingPolicyRequest,
-          com.google.protobuf.Empty>
-      METHOD_DELETE_AUTOSCALING_POLICY = getDeleteAutoscalingPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.DeleteAutoscalingPolicyRequest,
           com.google.protobuf.Empty>
       getDeleteAutoscalingPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteAutoscalingPolicy",
+      requestType = com.google.cloud.dataproc.v1beta2.DeleteAutoscalingPolicyRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.DeleteAutoscalingPolicyRequest,
           com.google.protobuf.Empty>
       getDeleteAutoscalingPolicyMethod() {
-    return getDeleteAutoscalingPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.DeleteAutoscalingPolicyRequest,
-          com.google.protobuf.Empty>
-      getDeleteAutoscalingPolicyMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.DeleteAutoscalingPolicyRequest,
             com.google.protobuf.Empty>
@@ -343,9 +285,7 @@ public final class AutoscalingPolicyServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.AutoscalingPolicyService",
-                              "DeleteAutoscalingPolicy"))
+                          generateFullMethodName(SERVICE_NAME, "DeleteAutoscalingPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -366,19 +306,43 @@ public final class AutoscalingPolicyServiceGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static AutoscalingPolicyServiceStub newStub(io.grpc.Channel channel) {
-    return new AutoscalingPolicyServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AutoscalingPolicyServiceStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AutoscalingPolicyServiceStub>() {
+          @java.lang.Override
+          public AutoscalingPolicyServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AutoscalingPolicyServiceStub(channel, callOptions);
+          }
+        };
+    return AutoscalingPolicyServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static AutoscalingPolicyServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new AutoscalingPolicyServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AutoscalingPolicyServiceBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AutoscalingPolicyServiceBlockingStub>() {
+          @java.lang.Override
+          public AutoscalingPolicyServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AutoscalingPolicyServiceBlockingStub(channel, callOptions);
+          }
+        };
+    return AutoscalingPolicyServiceBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static AutoscalingPolicyServiceFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new AutoscalingPolicyServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AutoscalingPolicyServiceFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AutoscalingPolicyServiceFutureStub>() {
+          @java.lang.Override
+          public AutoscalingPolicyServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AutoscalingPolicyServiceFutureStub(channel, callOptions);
+          }
+        };
+    return AutoscalingPolicyServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -402,7 +366,7 @@ public final class AutoscalingPolicyServiceGrpc {
         com.google.cloud.dataproc.v1beta2.CreateAutoscalingPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateAutoscalingPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateAutoscalingPolicyMethod(), responseObserver);
     }
 
     /**
@@ -418,7 +382,7 @@ public final class AutoscalingPolicyServiceGrpc {
         com.google.cloud.dataproc.v1beta2.UpdateAutoscalingPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateAutoscalingPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateAutoscalingPolicyMethod(), responseObserver);
     }
 
     /**
@@ -432,7 +396,7 @@ public final class AutoscalingPolicyServiceGrpc {
         com.google.cloud.dataproc.v1beta2.GetAutoscalingPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetAutoscalingPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetAutoscalingPolicyMethod(), responseObserver);
     }
 
     /**
@@ -447,7 +411,7 @@ public final class AutoscalingPolicyServiceGrpc {
         io.grpc.stub.StreamObserver<
                 com.google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListAutoscalingPoliciesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListAutoscalingPoliciesMethod(), responseObserver);
     }
 
     /**
@@ -461,42 +425,42 @@ public final class AutoscalingPolicyServiceGrpc {
     public void deleteAutoscalingPolicy(
         com.google.cloud.dataproc.v1beta2.DeleteAutoscalingPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteAutoscalingPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteAutoscalingPolicyMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getCreateAutoscalingPolicyMethodHelper(),
+              getCreateAutoscalingPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.CreateAutoscalingPolicyRequest,
                       com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>(
                       this, METHODID_CREATE_AUTOSCALING_POLICY)))
           .addMethod(
-              getUpdateAutoscalingPolicyMethodHelper(),
+              getUpdateAutoscalingPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.UpdateAutoscalingPolicyRequest,
                       com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>(
                       this, METHODID_UPDATE_AUTOSCALING_POLICY)))
           .addMethod(
-              getGetAutoscalingPolicyMethodHelper(),
+              getGetAutoscalingPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.GetAutoscalingPolicyRequest,
                       com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>(
                       this, METHODID_GET_AUTOSCALING_POLICY)))
           .addMethod(
-              getListAutoscalingPoliciesMethodHelper(),
+              getListAutoscalingPoliciesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesRequest,
                       com.google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesResponse>(
                       this, METHODID_LIST_AUTOSCALING_POLICIES)))
           .addMethod(
-              getDeleteAutoscalingPolicyMethodHelper(),
+              getDeleteAutoscalingPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.DeleteAutoscalingPolicyRequest,
@@ -514,11 +478,7 @@ public final class AutoscalingPolicyServiceGrpc {
    * </pre>
    */
   public static final class AutoscalingPolicyServiceStub
-      extends io.grpc.stub.AbstractStub<AutoscalingPolicyServiceStub> {
-    private AutoscalingPolicyServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<AutoscalingPolicyServiceStub> {
     private AutoscalingPolicyServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -541,7 +501,7 @@ public final class AutoscalingPolicyServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateAutoscalingPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateAutoscalingPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -560,7 +520,7 @@ public final class AutoscalingPolicyServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateAutoscalingPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateAutoscalingPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -577,7 +537,7 @@ public final class AutoscalingPolicyServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.AutoscalingPolicy>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetAutoscalingPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetAutoscalingPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -595,7 +555,7 @@ public final class AutoscalingPolicyServiceGrpc {
                 com.google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListAutoscalingPoliciesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListAutoscalingPoliciesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -612,7 +572,7 @@ public final class AutoscalingPolicyServiceGrpc {
         com.google.cloud.dataproc.v1beta2.DeleteAutoscalingPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteAutoscalingPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteAutoscalingPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -627,11 +587,7 @@ public final class AutoscalingPolicyServiceGrpc {
    * </pre>
    */
   public static final class AutoscalingPolicyServiceBlockingStub
-      extends io.grpc.stub.AbstractStub<AutoscalingPolicyServiceBlockingStub> {
-    private AutoscalingPolicyServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<AutoscalingPolicyServiceBlockingStub> {
     private AutoscalingPolicyServiceBlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -653,7 +609,7 @@ public final class AutoscalingPolicyServiceGrpc {
     public com.google.cloud.dataproc.v1beta2.AutoscalingPolicy createAutoscalingPolicy(
         com.google.cloud.dataproc.v1beta2.CreateAutoscalingPolicyRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateAutoscalingPolicyMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateAutoscalingPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -668,7 +624,7 @@ public final class AutoscalingPolicyServiceGrpc {
     public com.google.cloud.dataproc.v1beta2.AutoscalingPolicy updateAutoscalingPolicy(
         com.google.cloud.dataproc.v1beta2.UpdateAutoscalingPolicyRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateAutoscalingPolicyMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateAutoscalingPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -681,7 +637,7 @@ public final class AutoscalingPolicyServiceGrpc {
     public com.google.cloud.dataproc.v1beta2.AutoscalingPolicy getAutoscalingPolicy(
         com.google.cloud.dataproc.v1beta2.GetAutoscalingPolicyRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetAutoscalingPolicyMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetAutoscalingPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -695,7 +651,7 @@ public final class AutoscalingPolicyServiceGrpc {
         listAutoscalingPolicies(
             com.google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListAutoscalingPoliciesMethodHelper(), getCallOptions(), request);
+          getChannel(), getListAutoscalingPoliciesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -709,7 +665,7 @@ public final class AutoscalingPolicyServiceGrpc {
     public com.google.protobuf.Empty deleteAutoscalingPolicy(
         com.google.cloud.dataproc.v1beta2.DeleteAutoscalingPolicyRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteAutoscalingPolicyMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteAutoscalingPolicyMethod(), getCallOptions(), request);
     }
   }
 
@@ -722,11 +678,7 @@ public final class AutoscalingPolicyServiceGrpc {
    * </pre>
    */
   public static final class AutoscalingPolicyServiceFutureStub
-      extends io.grpc.stub.AbstractStub<AutoscalingPolicyServiceFutureStub> {
-    private AutoscalingPolicyServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<AutoscalingPolicyServiceFutureStub> {
     private AutoscalingPolicyServiceFutureStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -750,8 +702,7 @@ public final class AutoscalingPolicyServiceGrpc {
         createAutoscalingPolicy(
             com.google.cloud.dataproc.v1beta2.CreateAutoscalingPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateAutoscalingPolicyMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getCreateAutoscalingPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -768,8 +719,7 @@ public final class AutoscalingPolicyServiceGrpc {
         updateAutoscalingPolicy(
             com.google.cloud.dataproc.v1beta2.UpdateAutoscalingPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateAutoscalingPolicyMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getUpdateAutoscalingPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -784,7 +734,7 @@ public final class AutoscalingPolicyServiceGrpc {
         getAutoscalingPolicy(
             com.google.cloud.dataproc.v1beta2.GetAutoscalingPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetAutoscalingPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetAutoscalingPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -799,8 +749,7 @@ public final class AutoscalingPolicyServiceGrpc {
         listAutoscalingPolicies(
             com.google.cloud.dataproc.v1beta2.ListAutoscalingPoliciesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListAutoscalingPoliciesMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getListAutoscalingPoliciesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -815,8 +764,7 @@ public final class AutoscalingPolicyServiceGrpc {
         deleteAutoscalingPolicy(
             com.google.cloud.dataproc.v1beta2.DeleteAutoscalingPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteAutoscalingPolicyMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getDeleteAutoscalingPolicyMethod(), getCallOptions()), request);
     }
   }
 
@@ -937,11 +885,11 @@ public final class AutoscalingPolicyServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new AutoscalingPolicyServiceFileDescriptorSupplier())
-                      .addMethod(getCreateAutoscalingPolicyMethodHelper())
-                      .addMethod(getUpdateAutoscalingPolicyMethodHelper())
-                      .addMethod(getGetAutoscalingPolicyMethodHelper())
-                      .addMethod(getListAutoscalingPoliciesMethodHelper())
-                      .addMethod(getDeleteAutoscalingPolicyMethodHelper())
+                      .addMethod(getCreateAutoscalingPolicyMethod())
+                      .addMethod(getUpdateAutoscalingPolicyMethod())
+                      .addMethod(getGetAutoscalingPolicyMethod())
+                      .addMethod(getListAutoscalingPoliciesMethod())
+                      .addMethod(getDeleteAutoscalingPolicyMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dataproc-v1beta2/src/main/java/com/google/cloud/dataproc/v1beta2/ClusterControllerGrpc.java
+++ b/grpc-google-cloud-dataproc-v1beta2/src/main/java/com/google/cloud/dataproc/v1beta2/ClusterControllerGrpc.java
@@ -31,7 +31,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dataproc/v1beta2/clusters.proto")
 public final class ClusterControllerGrpc {
 
@@ -40,26 +40,18 @@ public final class ClusterControllerGrpc {
   public static final String SERVICE_NAME = "google.cloud.dataproc.v1beta2.ClusterController";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateClusterMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.CreateClusterRequest, com.google.longrunning.Operation>
-      METHOD_CREATE_CLUSTER = getCreateClusterMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.CreateClusterRequest, com.google.longrunning.Operation>
       getCreateClusterMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateCluster",
+      requestType = com.google.cloud.dataproc.v1beta2.CreateClusterRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.CreateClusterRequest, com.google.longrunning.Operation>
       getCreateClusterMethod() {
-    return getCreateClusterMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.CreateClusterRequest, com.google.longrunning.Operation>
-      getCreateClusterMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.CreateClusterRequest,
             com.google.longrunning.Operation>
@@ -74,9 +66,7 @@ public final class ClusterControllerGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.ClusterController", "CreateCluster"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateCluster"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -94,26 +84,18 @@ public final class ClusterControllerGrpc {
     return getCreateClusterMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateClusterMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.UpdateClusterRequest, com.google.longrunning.Operation>
-      METHOD_UPDATE_CLUSTER = getUpdateClusterMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.UpdateClusterRequest, com.google.longrunning.Operation>
       getUpdateClusterMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateCluster",
+      requestType = com.google.cloud.dataproc.v1beta2.UpdateClusterRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.UpdateClusterRequest, com.google.longrunning.Operation>
       getUpdateClusterMethod() {
-    return getUpdateClusterMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.UpdateClusterRequest, com.google.longrunning.Operation>
-      getUpdateClusterMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.UpdateClusterRequest,
             com.google.longrunning.Operation>
@@ -128,9 +110,7 @@ public final class ClusterControllerGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.ClusterController", "UpdateCluster"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateCluster"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -148,26 +128,18 @@ public final class ClusterControllerGrpc {
     return getUpdateClusterMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteClusterMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.DeleteClusterRequest, com.google.longrunning.Operation>
-      METHOD_DELETE_CLUSTER = getDeleteClusterMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.DeleteClusterRequest, com.google.longrunning.Operation>
       getDeleteClusterMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteCluster",
+      requestType = com.google.cloud.dataproc.v1beta2.DeleteClusterRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.DeleteClusterRequest, com.google.longrunning.Operation>
       getDeleteClusterMethod() {
-    return getDeleteClusterMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.DeleteClusterRequest, com.google.longrunning.Operation>
-      getDeleteClusterMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.DeleteClusterRequest,
             com.google.longrunning.Operation>
@@ -182,9 +154,7 @@ public final class ClusterControllerGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.ClusterController", "DeleteCluster"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteCluster"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -202,30 +172,20 @@ public final class ClusterControllerGrpc {
     return getDeleteClusterMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetClusterMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.GetClusterRequest,
-          com.google.cloud.dataproc.v1beta2.Cluster>
-      METHOD_GET_CLUSTER = getGetClusterMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.GetClusterRequest,
           com.google.cloud.dataproc.v1beta2.Cluster>
       getGetClusterMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetCluster",
+      requestType = com.google.cloud.dataproc.v1beta2.GetClusterRequest.class,
+      responseType = com.google.cloud.dataproc.v1beta2.Cluster.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.GetClusterRequest,
           com.google.cloud.dataproc.v1beta2.Cluster>
       getGetClusterMethod() {
-    return getGetClusterMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.GetClusterRequest,
-          com.google.cloud.dataproc.v1beta2.Cluster>
-      getGetClusterMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.GetClusterRequest,
             com.google.cloud.dataproc.v1beta2.Cluster>
@@ -240,9 +200,7 @@ public final class ClusterControllerGrpc {
                           com.google.cloud.dataproc.v1beta2.Cluster>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.ClusterController", "GetCluster"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetCluster"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -260,30 +218,20 @@ public final class ClusterControllerGrpc {
     return getGetClusterMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListClustersMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.ListClustersRequest,
-          com.google.cloud.dataproc.v1beta2.ListClustersResponse>
-      METHOD_LIST_CLUSTERS = getListClustersMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.ListClustersRequest,
           com.google.cloud.dataproc.v1beta2.ListClustersResponse>
       getListClustersMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListClusters",
+      requestType = com.google.cloud.dataproc.v1beta2.ListClustersRequest.class,
+      responseType = com.google.cloud.dataproc.v1beta2.ListClustersResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.ListClustersRequest,
           com.google.cloud.dataproc.v1beta2.ListClustersResponse>
       getListClustersMethod() {
-    return getListClustersMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.ListClustersRequest,
-          com.google.cloud.dataproc.v1beta2.ListClustersResponse>
-      getListClustersMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.ListClustersRequest,
             com.google.cloud.dataproc.v1beta2.ListClustersResponse>
@@ -298,9 +246,7 @@ public final class ClusterControllerGrpc {
                           com.google.cloud.dataproc.v1beta2.ListClustersResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.ClusterController", "ListClusters"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListClusters"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -319,30 +265,20 @@ public final class ClusterControllerGrpc {
     return getListClustersMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDiagnoseClusterMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.DiagnoseClusterRequest,
-          com.google.longrunning.Operation>
-      METHOD_DIAGNOSE_CLUSTER = getDiagnoseClusterMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.DiagnoseClusterRequest,
           com.google.longrunning.Operation>
       getDiagnoseClusterMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DiagnoseCluster",
+      requestType = com.google.cloud.dataproc.v1beta2.DiagnoseClusterRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.DiagnoseClusterRequest,
           com.google.longrunning.Operation>
       getDiagnoseClusterMethod() {
-    return getDiagnoseClusterMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.DiagnoseClusterRequest,
-          com.google.longrunning.Operation>
-      getDiagnoseClusterMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.DiagnoseClusterRequest,
             com.google.longrunning.Operation>
@@ -357,9 +293,7 @@ public final class ClusterControllerGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.ClusterController", "DiagnoseCluster"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DiagnoseCluster"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -379,19 +313,43 @@ public final class ClusterControllerGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static ClusterControllerStub newStub(io.grpc.Channel channel) {
-    return new ClusterControllerStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ClusterControllerStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ClusterControllerStub>() {
+          @java.lang.Override
+          public ClusterControllerStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ClusterControllerStub(channel, callOptions);
+          }
+        };
+    return ClusterControllerStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static ClusterControllerBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new ClusterControllerBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ClusterControllerBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ClusterControllerBlockingStub>() {
+          @java.lang.Override
+          public ClusterControllerBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ClusterControllerBlockingStub(channel, callOptions);
+          }
+        };
+    return ClusterControllerBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static ClusterControllerFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new ClusterControllerFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<ClusterControllerFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<ClusterControllerFutureStub>() {
+          @java.lang.Override
+          public ClusterControllerFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new ClusterControllerFutureStub(channel, callOptions);
+          }
+        };
+    return ClusterControllerFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -416,7 +374,7 @@ public final class ClusterControllerGrpc {
     public void createCluster(
         com.google.cloud.dataproc.v1beta2.CreateClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateClusterMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateClusterMethod(), responseObserver);
     }
 
     /**
@@ -431,7 +389,7 @@ public final class ClusterControllerGrpc {
     public void updateCluster(
         com.google.cloud.dataproc.v1beta2.UpdateClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateClusterMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateClusterMethod(), responseObserver);
     }
 
     /**
@@ -446,7 +404,7 @@ public final class ClusterControllerGrpc {
     public void deleteCluster(
         com.google.cloud.dataproc.v1beta2.DeleteClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteClusterMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteClusterMethod(), responseObserver);
     }
 
     /**
@@ -459,7 +417,7 @@ public final class ClusterControllerGrpc {
     public void getCluster(
         com.google.cloud.dataproc.v1beta2.GetClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.Cluster> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetClusterMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetClusterMethod(), responseObserver);
     }
 
     /**
@@ -473,7 +431,7 @@ public final class ClusterControllerGrpc {
         com.google.cloud.dataproc.v1beta2.ListClustersRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.ListClustersResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListClustersMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListClustersMethod(), responseObserver);
     }
 
     /**
@@ -492,45 +450,45 @@ public final class ClusterControllerGrpc {
     public void diagnoseCluster(
         com.google.cloud.dataproc.v1beta2.DiagnoseClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getDiagnoseClusterMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDiagnoseClusterMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getCreateClusterMethodHelper(),
+              getCreateClusterMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.CreateClusterRequest,
                       com.google.longrunning.Operation>(this, METHODID_CREATE_CLUSTER)))
           .addMethod(
-              getUpdateClusterMethodHelper(),
+              getUpdateClusterMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.UpdateClusterRequest,
                       com.google.longrunning.Operation>(this, METHODID_UPDATE_CLUSTER)))
           .addMethod(
-              getDeleteClusterMethodHelper(),
+              getDeleteClusterMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.DeleteClusterRequest,
                       com.google.longrunning.Operation>(this, METHODID_DELETE_CLUSTER)))
           .addMethod(
-              getGetClusterMethodHelper(),
+              getGetClusterMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.GetClusterRequest,
                       com.google.cloud.dataproc.v1beta2.Cluster>(this, METHODID_GET_CLUSTER)))
           .addMethod(
-              getListClustersMethodHelper(),
+              getListClustersMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.ListClustersRequest,
                       com.google.cloud.dataproc.v1beta2.ListClustersResponse>(
                       this, METHODID_LIST_CLUSTERS)))
           .addMethod(
-              getDiagnoseClusterMethodHelper(),
+              getDiagnoseClusterMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.DiagnoseClusterRequest,
@@ -548,11 +506,7 @@ public final class ClusterControllerGrpc {
    * </pre>
    */
   public static final class ClusterControllerStub
-      extends io.grpc.stub.AbstractStub<ClusterControllerStub> {
-    private ClusterControllerStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<ClusterControllerStub> {
     private ClusterControllerStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -576,7 +530,7 @@ public final class ClusterControllerGrpc {
         com.google.cloud.dataproc.v1beta2.CreateClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateClusterMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateClusterMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -594,7 +548,7 @@ public final class ClusterControllerGrpc {
         com.google.cloud.dataproc.v1beta2.UpdateClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateClusterMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateClusterMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -612,7 +566,7 @@ public final class ClusterControllerGrpc {
         com.google.cloud.dataproc.v1beta2.DeleteClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteClusterMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteClusterMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -628,9 +582,7 @@ public final class ClusterControllerGrpc {
         com.google.cloud.dataproc.v1beta2.GetClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.Cluster> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetClusterMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetClusterMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -645,7 +597,7 @@ public final class ClusterControllerGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.ListClustersResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListClustersMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListClustersMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -667,7 +619,7 @@ public final class ClusterControllerGrpc {
         com.google.cloud.dataproc.v1beta2.DiagnoseClusterRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDiagnoseClusterMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDiagnoseClusterMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -682,11 +634,7 @@ public final class ClusterControllerGrpc {
    * </pre>
    */
   public static final class ClusterControllerBlockingStub
-      extends io.grpc.stub.AbstractStub<ClusterControllerBlockingStub> {
-    private ClusterControllerBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<ClusterControllerBlockingStub> {
     private ClusterControllerBlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -709,8 +657,7 @@ public final class ClusterControllerGrpc {
      */
     public com.google.longrunning.Operation createCluster(
         com.google.cloud.dataproc.v1beta2.CreateClusterRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateClusterMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateClusterMethod(), getCallOptions(), request);
     }
 
     /**
@@ -724,8 +671,7 @@ public final class ClusterControllerGrpc {
      */
     public com.google.longrunning.Operation updateCluster(
         com.google.cloud.dataproc.v1beta2.UpdateClusterRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateClusterMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateClusterMethod(), getCallOptions(), request);
     }
 
     /**
@@ -739,8 +685,7 @@ public final class ClusterControllerGrpc {
      */
     public com.google.longrunning.Operation deleteCluster(
         com.google.cloud.dataproc.v1beta2.DeleteClusterRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteClusterMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteClusterMethod(), getCallOptions(), request);
     }
 
     /**
@@ -752,8 +697,7 @@ public final class ClusterControllerGrpc {
      */
     public com.google.cloud.dataproc.v1beta2.Cluster getCluster(
         com.google.cloud.dataproc.v1beta2.GetClusterRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetClusterMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetClusterMethod(), getCallOptions(), request);
     }
 
     /**
@@ -765,8 +709,7 @@ public final class ClusterControllerGrpc {
      */
     public com.google.cloud.dataproc.v1beta2.ListClustersResponse listClusters(
         com.google.cloud.dataproc.v1beta2.ListClustersRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListClustersMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListClustersMethod(), getCallOptions(), request);
     }
 
     /**
@@ -784,8 +727,7 @@ public final class ClusterControllerGrpc {
      */
     public com.google.longrunning.Operation diagnoseCluster(
         com.google.cloud.dataproc.v1beta2.DiagnoseClusterRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDiagnoseClusterMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDiagnoseClusterMethod(), getCallOptions(), request);
     }
   }
 
@@ -798,11 +740,7 @@ public final class ClusterControllerGrpc {
    * </pre>
    */
   public static final class ClusterControllerFutureStub
-      extends io.grpc.stub.AbstractStub<ClusterControllerFutureStub> {
-    private ClusterControllerFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<ClusterControllerFutureStub> {
     private ClusterControllerFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -825,7 +763,7 @@ public final class ClusterControllerGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         createCluster(com.google.cloud.dataproc.v1beta2.CreateClusterRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateClusterMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateClusterMethod(), getCallOptions()), request);
     }
 
     /**
@@ -840,7 +778,7 @@ public final class ClusterControllerGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         updateCluster(com.google.cloud.dataproc.v1beta2.UpdateClusterRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateClusterMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateClusterMethod(), getCallOptions()), request);
     }
 
     /**
@@ -855,7 +793,7 @@ public final class ClusterControllerGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         deleteCluster(com.google.cloud.dataproc.v1beta2.DeleteClusterRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteClusterMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteClusterMethod(), getCallOptions()), request);
     }
 
     /**
@@ -869,7 +807,7 @@ public final class ClusterControllerGrpc {
             com.google.cloud.dataproc.v1beta2.Cluster>
         getCluster(com.google.cloud.dataproc.v1beta2.GetClusterRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetClusterMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetClusterMethod(), getCallOptions()), request);
     }
 
     /**
@@ -883,7 +821,7 @@ public final class ClusterControllerGrpc {
             com.google.cloud.dataproc.v1beta2.ListClustersResponse>
         listClusters(com.google.cloud.dataproc.v1beta2.ListClustersRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListClustersMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListClustersMethod(), getCallOptions()), request);
     }
 
     /**
@@ -902,7 +840,7 @@ public final class ClusterControllerGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         diagnoseCluster(com.google.cloud.dataproc.v1beta2.DiagnoseClusterRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDiagnoseClusterMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDiagnoseClusterMethod(), getCallOptions()), request);
     }
   }
 
@@ -1026,12 +964,12 @@ public final class ClusterControllerGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new ClusterControllerFileDescriptorSupplier())
-                      .addMethod(getCreateClusterMethodHelper())
-                      .addMethod(getUpdateClusterMethodHelper())
-                      .addMethod(getDeleteClusterMethodHelper())
-                      .addMethod(getGetClusterMethodHelper())
-                      .addMethod(getListClustersMethodHelper())
-                      .addMethod(getDiagnoseClusterMethodHelper())
+                      .addMethod(getCreateClusterMethod())
+                      .addMethod(getUpdateClusterMethod())
+                      .addMethod(getDeleteClusterMethod())
+                      .addMethod(getGetClusterMethod())
+                      .addMethod(getListClustersMethod())
+                      .addMethod(getDiagnoseClusterMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dataproc-v1beta2/src/main/java/com/google/cloud/dataproc/v1beta2/JobControllerGrpc.java
+++ b/grpc-google-cloud-dataproc-v1beta2/src/main/java/com/google/cloud/dataproc/v1beta2/JobControllerGrpc.java
@@ -30,7 +30,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dataproc/v1beta2/jobs.proto")
 public final class JobControllerGrpc {
 
@@ -39,26 +39,18 @@ public final class JobControllerGrpc {
   public static final String SERVICE_NAME = "google.cloud.dataproc.v1beta2.JobController";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSubmitJobMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.SubmitJobRequest, com.google.cloud.dataproc.v1beta2.Job>
-      METHOD_SUBMIT_JOB = getSubmitJobMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.SubmitJobRequest, com.google.cloud.dataproc.v1beta2.Job>
       getSubmitJobMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SubmitJob",
+      requestType = com.google.cloud.dataproc.v1beta2.SubmitJobRequest.class,
+      responseType = com.google.cloud.dataproc.v1beta2.Job.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.SubmitJobRequest, com.google.cloud.dataproc.v1beta2.Job>
       getSubmitJobMethod() {
-    return getSubmitJobMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.SubmitJobRequest, com.google.cloud.dataproc.v1beta2.Job>
-      getSubmitJobMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.SubmitJobRequest,
             com.google.cloud.dataproc.v1beta2.Job>
@@ -73,9 +65,7 @@ public final class JobControllerGrpc {
                           com.google.cloud.dataproc.v1beta2.Job>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.JobController", "SubmitJob"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SubmitJob"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -92,26 +82,18 @@ public final class JobControllerGrpc {
     return getSubmitJobMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetJobMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.GetJobRequest, com.google.cloud.dataproc.v1beta2.Job>
-      METHOD_GET_JOB = getGetJobMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.GetJobRequest, com.google.cloud.dataproc.v1beta2.Job>
       getGetJobMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetJob",
+      requestType = com.google.cloud.dataproc.v1beta2.GetJobRequest.class,
+      responseType = com.google.cloud.dataproc.v1beta2.Job.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.GetJobRequest, com.google.cloud.dataproc.v1beta2.Job>
       getGetJobMethod() {
-    return getGetJobMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.GetJobRequest, com.google.cloud.dataproc.v1beta2.Job>
-      getGetJobMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.GetJobRequest, com.google.cloud.dataproc.v1beta2.Job>
         getGetJobMethod;
@@ -125,9 +107,7 @@ public final class JobControllerGrpc {
                           com.google.cloud.dataproc.v1beta2.Job>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.JobController", "GetJob"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetJob"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -143,30 +123,20 @@ public final class JobControllerGrpc {
     return getGetJobMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListJobsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.ListJobsRequest,
-          com.google.cloud.dataproc.v1beta2.ListJobsResponse>
-      METHOD_LIST_JOBS = getListJobsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.ListJobsRequest,
           com.google.cloud.dataproc.v1beta2.ListJobsResponse>
       getListJobsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListJobs",
+      requestType = com.google.cloud.dataproc.v1beta2.ListJobsRequest.class,
+      responseType = com.google.cloud.dataproc.v1beta2.ListJobsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.ListJobsRequest,
           com.google.cloud.dataproc.v1beta2.ListJobsResponse>
       getListJobsMethod() {
-    return getListJobsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.ListJobsRequest,
-          com.google.cloud.dataproc.v1beta2.ListJobsResponse>
-      getListJobsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.ListJobsRequest,
             com.google.cloud.dataproc.v1beta2.ListJobsResponse>
@@ -181,9 +151,7 @@ public final class JobControllerGrpc {
                           com.google.cloud.dataproc.v1beta2.ListJobsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.JobController", "ListJobs"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListJobs"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -201,26 +169,18 @@ public final class JobControllerGrpc {
     return getListJobsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateJobMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.UpdateJobRequest, com.google.cloud.dataproc.v1beta2.Job>
-      METHOD_UPDATE_JOB = getUpdateJobMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.UpdateJobRequest, com.google.cloud.dataproc.v1beta2.Job>
       getUpdateJobMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateJob",
+      requestType = com.google.cloud.dataproc.v1beta2.UpdateJobRequest.class,
+      responseType = com.google.cloud.dataproc.v1beta2.Job.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.UpdateJobRequest, com.google.cloud.dataproc.v1beta2.Job>
       getUpdateJobMethod() {
-    return getUpdateJobMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.UpdateJobRequest, com.google.cloud.dataproc.v1beta2.Job>
-      getUpdateJobMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.UpdateJobRequest,
             com.google.cloud.dataproc.v1beta2.Job>
@@ -235,9 +195,7 @@ public final class JobControllerGrpc {
                           com.google.cloud.dataproc.v1beta2.Job>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.JobController", "UpdateJob"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateJob"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -254,26 +212,18 @@ public final class JobControllerGrpc {
     return getUpdateJobMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCancelJobMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.CancelJobRequest, com.google.cloud.dataproc.v1beta2.Job>
-      METHOD_CANCEL_JOB = getCancelJobMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.CancelJobRequest, com.google.cloud.dataproc.v1beta2.Job>
       getCancelJobMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CancelJob",
+      requestType = com.google.cloud.dataproc.v1beta2.CancelJobRequest.class,
+      responseType = com.google.cloud.dataproc.v1beta2.Job.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.CancelJobRequest, com.google.cloud.dataproc.v1beta2.Job>
       getCancelJobMethod() {
-    return getCancelJobMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.CancelJobRequest, com.google.cloud.dataproc.v1beta2.Job>
-      getCancelJobMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.CancelJobRequest,
             com.google.cloud.dataproc.v1beta2.Job>
@@ -288,9 +238,7 @@ public final class JobControllerGrpc {
                           com.google.cloud.dataproc.v1beta2.Job>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.JobController", "CancelJob"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CancelJob"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -307,26 +255,18 @@ public final class JobControllerGrpc {
     return getCancelJobMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteJobMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.DeleteJobRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_JOB = getDeleteJobMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.DeleteJobRequest, com.google.protobuf.Empty>
       getDeleteJobMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteJob",
+      requestType = com.google.cloud.dataproc.v1beta2.DeleteJobRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.DeleteJobRequest, com.google.protobuf.Empty>
       getDeleteJobMethod() {
-    return getDeleteJobMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.DeleteJobRequest, com.google.protobuf.Empty>
-      getDeleteJobMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.DeleteJobRequest, com.google.protobuf.Empty>
         getDeleteJobMethod;
@@ -340,9 +280,7 @@ public final class JobControllerGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.JobController", "DeleteJob"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteJob"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -361,19 +299,43 @@ public final class JobControllerGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static JobControllerStub newStub(io.grpc.Channel channel) {
-    return new JobControllerStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<JobControllerStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<JobControllerStub>() {
+          @java.lang.Override
+          public JobControllerStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new JobControllerStub(channel, callOptions);
+          }
+        };
+    return JobControllerStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static JobControllerBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new JobControllerBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<JobControllerBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<JobControllerBlockingStub>() {
+          @java.lang.Override
+          public JobControllerBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new JobControllerBlockingStub(channel, callOptions);
+          }
+        };
+    return JobControllerBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static JobControllerFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new JobControllerFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<JobControllerFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<JobControllerFutureStub>() {
+          @java.lang.Override
+          public JobControllerFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new JobControllerFutureStub(channel, callOptions);
+          }
+        };
+    return JobControllerFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -395,7 +357,7 @@ public final class JobControllerGrpc {
     public void submitJob(
         com.google.cloud.dataproc.v1beta2.SubmitJobRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.Job> responseObserver) {
-      asyncUnimplementedUnaryCall(getSubmitJobMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getSubmitJobMethod(), responseObserver);
     }
 
     /**
@@ -408,7 +370,7 @@ public final class JobControllerGrpc {
     public void getJob(
         com.google.cloud.dataproc.v1beta2.GetJobRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.Job> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetJobMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetJobMethod(), responseObserver);
     }
 
     /**
@@ -422,7 +384,7 @@ public final class JobControllerGrpc {
         com.google.cloud.dataproc.v1beta2.ListJobsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.ListJobsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListJobsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListJobsMethod(), responseObserver);
     }
 
     /**
@@ -435,7 +397,7 @@ public final class JobControllerGrpc {
     public void updateJob(
         com.google.cloud.dataproc.v1beta2.UpdateJobRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.Job> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateJobMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateJobMethod(), responseObserver);
     }
 
     /**
@@ -452,7 +414,7 @@ public final class JobControllerGrpc {
     public void cancelJob(
         com.google.cloud.dataproc.v1beta2.CancelJobRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.Job> responseObserver) {
-      asyncUnimplementedUnaryCall(getCancelJobMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCancelJobMethod(), responseObserver);
     }
 
     /**
@@ -466,45 +428,45 @@ public final class JobControllerGrpc {
     public void deleteJob(
         com.google.cloud.dataproc.v1beta2.DeleteJobRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteJobMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteJobMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getSubmitJobMethodHelper(),
+              getSubmitJobMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.SubmitJobRequest,
                       com.google.cloud.dataproc.v1beta2.Job>(this, METHODID_SUBMIT_JOB)))
           .addMethod(
-              getGetJobMethodHelper(),
+              getGetJobMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.GetJobRequest,
                       com.google.cloud.dataproc.v1beta2.Job>(this, METHODID_GET_JOB)))
           .addMethod(
-              getListJobsMethodHelper(),
+              getListJobsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.ListJobsRequest,
                       com.google.cloud.dataproc.v1beta2.ListJobsResponse>(
                       this, METHODID_LIST_JOBS)))
           .addMethod(
-              getUpdateJobMethodHelper(),
+              getUpdateJobMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.UpdateJobRequest,
                       com.google.cloud.dataproc.v1beta2.Job>(this, METHODID_UPDATE_JOB)))
           .addMethod(
-              getCancelJobMethodHelper(),
+              getCancelJobMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.CancelJobRequest,
                       com.google.cloud.dataproc.v1beta2.Job>(this, METHODID_CANCEL_JOB)))
           .addMethod(
-              getDeleteJobMethodHelper(),
+              getDeleteJobMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.DeleteJobRequest,
@@ -520,11 +482,8 @@ public final class JobControllerGrpc {
    * The JobController provides methods to manage jobs.
    * </pre>
    */
-  public static final class JobControllerStub extends io.grpc.stub.AbstractStub<JobControllerStub> {
-    private JobControllerStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class JobControllerStub
+      extends io.grpc.stub.AbstractAsyncStub<JobControllerStub> {
     private JobControllerStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -545,9 +504,7 @@ public final class JobControllerGrpc {
         com.google.cloud.dataproc.v1beta2.SubmitJobRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.Job> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getSubmitJobMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getSubmitJobMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -561,9 +518,7 @@ public final class JobControllerGrpc {
         com.google.cloud.dataproc.v1beta2.GetJobRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.Job> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetJobMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetJobMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -578,9 +533,7 @@ public final class JobControllerGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.ListJobsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListJobsMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getListJobsMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -594,9 +547,7 @@ public final class JobControllerGrpc {
         com.google.cloud.dataproc.v1beta2.UpdateJobRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.Job> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateJobMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getUpdateJobMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -614,9 +565,7 @@ public final class JobControllerGrpc {
         com.google.cloud.dataproc.v1beta2.CancelJobRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.Job> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCancelJobMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getCancelJobMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -631,9 +580,7 @@ public final class JobControllerGrpc {
         com.google.cloud.dataproc.v1beta2.DeleteJobRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteJobMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getDeleteJobMethod(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -645,11 +592,7 @@ public final class JobControllerGrpc {
    * </pre>
    */
   public static final class JobControllerBlockingStub
-      extends io.grpc.stub.AbstractStub<JobControllerBlockingStub> {
-    private JobControllerBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<JobControllerBlockingStub> {
     private JobControllerBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -669,7 +612,7 @@ public final class JobControllerGrpc {
      */
     public com.google.cloud.dataproc.v1beta2.Job submitJob(
         com.google.cloud.dataproc.v1beta2.SubmitJobRequest request) {
-      return blockingUnaryCall(getChannel(), getSubmitJobMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getSubmitJobMethod(), getCallOptions(), request);
     }
 
     /**
@@ -681,7 +624,7 @@ public final class JobControllerGrpc {
      */
     public com.google.cloud.dataproc.v1beta2.Job getJob(
         com.google.cloud.dataproc.v1beta2.GetJobRequest request) {
-      return blockingUnaryCall(getChannel(), getGetJobMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetJobMethod(), getCallOptions(), request);
     }
 
     /**
@@ -693,7 +636,7 @@ public final class JobControllerGrpc {
      */
     public com.google.cloud.dataproc.v1beta2.ListJobsResponse listJobs(
         com.google.cloud.dataproc.v1beta2.ListJobsRequest request) {
-      return blockingUnaryCall(getChannel(), getListJobsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListJobsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -705,7 +648,7 @@ public final class JobControllerGrpc {
      */
     public com.google.cloud.dataproc.v1beta2.Job updateJob(
         com.google.cloud.dataproc.v1beta2.UpdateJobRequest request) {
-      return blockingUnaryCall(getChannel(), getUpdateJobMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateJobMethod(), getCallOptions(), request);
     }
 
     /**
@@ -721,7 +664,7 @@ public final class JobControllerGrpc {
      */
     public com.google.cloud.dataproc.v1beta2.Job cancelJob(
         com.google.cloud.dataproc.v1beta2.CancelJobRequest request) {
-      return blockingUnaryCall(getChannel(), getCancelJobMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCancelJobMethod(), getCallOptions(), request);
     }
 
     /**
@@ -734,7 +677,7 @@ public final class JobControllerGrpc {
      */
     public com.google.protobuf.Empty deleteJob(
         com.google.cloud.dataproc.v1beta2.DeleteJobRequest request) {
-      return blockingUnaryCall(getChannel(), getDeleteJobMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteJobMethod(), getCallOptions(), request);
     }
   }
 
@@ -746,11 +689,7 @@ public final class JobControllerGrpc {
    * </pre>
    */
   public static final class JobControllerFutureStub
-      extends io.grpc.stub.AbstractStub<JobControllerFutureStub> {
-    private JobControllerFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<JobControllerFutureStub> {
     private JobControllerFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -770,8 +709,7 @@ public final class JobControllerGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.dataproc.v1beta2.Job>
         submitJob(com.google.cloud.dataproc.v1beta2.SubmitJobRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getSubmitJobMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getSubmitJobMethod(), getCallOptions()), request);
     }
 
     /**
@@ -783,8 +721,7 @@ public final class JobControllerGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.dataproc.v1beta2.Job>
         getJob(com.google.cloud.dataproc.v1beta2.GetJobRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getGetJobMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getGetJobMethod(), getCallOptions()), request);
     }
 
     /**
@@ -797,8 +734,7 @@ public final class JobControllerGrpc {
     public com.google.common.util.concurrent.ListenableFuture<
             com.google.cloud.dataproc.v1beta2.ListJobsResponse>
         listJobs(com.google.cloud.dataproc.v1beta2.ListJobsRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getListJobsMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getListJobsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -810,8 +746,7 @@ public final class JobControllerGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.dataproc.v1beta2.Job>
         updateJob(com.google.cloud.dataproc.v1beta2.UpdateJobRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getUpdateJobMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getUpdateJobMethod(), getCallOptions()), request);
     }
 
     /**
@@ -827,8 +762,7 @@ public final class JobControllerGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.dataproc.v1beta2.Job>
         cancelJob(com.google.cloud.dataproc.v1beta2.CancelJobRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getCancelJobMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getCancelJobMethod(), getCallOptions()), request);
     }
 
     /**
@@ -841,8 +775,7 @@ public final class JobControllerGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> deleteJob(
         com.google.cloud.dataproc.v1beta2.DeleteJobRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getDeleteJobMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getDeleteJobMethod(), getCallOptions()), request);
     }
   }
 
@@ -969,12 +902,12 @@ public final class JobControllerGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new JobControllerFileDescriptorSupplier())
-                      .addMethod(getSubmitJobMethodHelper())
-                      .addMethod(getGetJobMethodHelper())
-                      .addMethod(getListJobsMethodHelper())
-                      .addMethod(getUpdateJobMethodHelper())
-                      .addMethod(getCancelJobMethodHelper())
-                      .addMethod(getDeleteJobMethodHelper())
+                      .addMethod(getSubmitJobMethod())
+                      .addMethod(getGetJobMethod())
+                      .addMethod(getListJobsMethod())
+                      .addMethod(getUpdateJobMethod())
+                      .addMethod(getCancelJobMethod())
+                      .addMethod(getDeleteJobMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-dataproc-v1beta2/src/main/java/com/google/cloud/dataproc/v1beta2/WorkflowTemplateServiceGrpc.java
+++ b/grpc-google-cloud-dataproc-v1beta2/src/main/java/com/google/cloud/dataproc/v1beta2/WorkflowTemplateServiceGrpc.java
@@ -31,7 +31,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/dataproc/v1beta2/workflow_templates.proto")
 public final class WorkflowTemplateServiceGrpc {
 
@@ -40,30 +40,20 @@ public final class WorkflowTemplateServiceGrpc {
   public static final String SERVICE_NAME = "google.cloud.dataproc.v1beta2.WorkflowTemplateService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateWorkflowTemplateMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.CreateWorkflowTemplateRequest,
-          com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
-      METHOD_CREATE_WORKFLOW_TEMPLATE = getCreateWorkflowTemplateMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.CreateWorkflowTemplateRequest,
           com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
       getCreateWorkflowTemplateMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateWorkflowTemplate",
+      requestType = com.google.cloud.dataproc.v1beta2.CreateWorkflowTemplateRequest.class,
+      responseType = com.google.cloud.dataproc.v1beta2.WorkflowTemplate.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.CreateWorkflowTemplateRequest,
           com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
       getCreateWorkflowTemplateMethod() {
-    return getCreateWorkflowTemplateMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.CreateWorkflowTemplateRequest,
-          com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
-      getCreateWorkflowTemplateMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.CreateWorkflowTemplateRequest,
             com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
@@ -83,9 +73,7 @@ public final class WorkflowTemplateServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.WorkflowTemplateService",
-                              "CreateWorkflowTemplate"))
+                          generateFullMethodName(SERVICE_NAME, "CreateWorkflowTemplate"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -105,30 +93,20 @@ public final class WorkflowTemplateServiceGrpc {
     return getCreateWorkflowTemplateMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetWorkflowTemplateMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.GetWorkflowTemplateRequest,
-          com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
-      METHOD_GET_WORKFLOW_TEMPLATE = getGetWorkflowTemplateMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.GetWorkflowTemplateRequest,
           com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
       getGetWorkflowTemplateMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetWorkflowTemplate",
+      requestType = com.google.cloud.dataproc.v1beta2.GetWorkflowTemplateRequest.class,
+      responseType = com.google.cloud.dataproc.v1beta2.WorkflowTemplate.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.GetWorkflowTemplateRequest,
           com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
       getGetWorkflowTemplateMethod() {
-    return getGetWorkflowTemplateMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.GetWorkflowTemplateRequest,
-          com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
-      getGetWorkflowTemplateMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.GetWorkflowTemplateRequest,
             com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
@@ -147,9 +125,7 @@ public final class WorkflowTemplateServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.WorkflowTemplateService",
-                              "GetWorkflowTemplate"))
+                          generateFullMethodName(SERVICE_NAME, "GetWorkflowTemplate"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -169,30 +145,20 @@ public final class WorkflowTemplateServiceGrpc {
     return getGetWorkflowTemplateMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getInstantiateWorkflowTemplateMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.InstantiateWorkflowTemplateRequest,
-          com.google.longrunning.Operation>
-      METHOD_INSTANTIATE_WORKFLOW_TEMPLATE = getInstantiateWorkflowTemplateMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.InstantiateWorkflowTemplateRequest,
           com.google.longrunning.Operation>
       getInstantiateWorkflowTemplateMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "InstantiateWorkflowTemplate",
+      requestType = com.google.cloud.dataproc.v1beta2.InstantiateWorkflowTemplateRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.InstantiateWorkflowTemplateRequest,
           com.google.longrunning.Operation>
       getInstantiateWorkflowTemplateMethod() {
-    return getInstantiateWorkflowTemplateMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.InstantiateWorkflowTemplateRequest,
-          com.google.longrunning.Operation>
-      getInstantiateWorkflowTemplateMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.InstantiateWorkflowTemplateRequest,
             com.google.longrunning.Operation>
@@ -212,9 +178,7 @@ public final class WorkflowTemplateServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.WorkflowTemplateService",
-                              "InstantiateWorkflowTemplate"))
+                          generateFullMethodName(SERVICE_NAME, "InstantiateWorkflowTemplate"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -233,31 +197,21 @@ public final class WorkflowTemplateServiceGrpc {
     return getInstantiateWorkflowTemplateMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getInstantiateInlineWorkflowTemplateMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.InstantiateInlineWorkflowTemplateRequest,
-          com.google.longrunning.Operation>
-      METHOD_INSTANTIATE_INLINE_WORKFLOW_TEMPLATE =
-          getInstantiateInlineWorkflowTemplateMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.InstantiateInlineWorkflowTemplateRequest,
           com.google.longrunning.Operation>
       getInstantiateInlineWorkflowTemplateMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "InstantiateInlineWorkflowTemplate",
+      requestType =
+          com.google.cloud.dataproc.v1beta2.InstantiateInlineWorkflowTemplateRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.InstantiateInlineWorkflowTemplateRequest,
           com.google.longrunning.Operation>
       getInstantiateInlineWorkflowTemplateMethod() {
-    return getInstantiateInlineWorkflowTemplateMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.InstantiateInlineWorkflowTemplateRequest,
-          com.google.longrunning.Operation>
-      getInstantiateInlineWorkflowTemplateMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.InstantiateInlineWorkflowTemplateRequest,
             com.google.longrunning.Operation>
@@ -277,9 +231,7 @@ public final class WorkflowTemplateServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.WorkflowTemplateService",
-                              "InstantiateInlineWorkflowTemplate"))
+                          generateFullMethodName(SERVICE_NAME, "InstantiateInlineWorkflowTemplate"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -298,30 +250,20 @@ public final class WorkflowTemplateServiceGrpc {
     return getInstantiateInlineWorkflowTemplateMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateWorkflowTemplateMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.UpdateWorkflowTemplateRequest,
-          com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
-      METHOD_UPDATE_WORKFLOW_TEMPLATE = getUpdateWorkflowTemplateMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.UpdateWorkflowTemplateRequest,
           com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
       getUpdateWorkflowTemplateMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateWorkflowTemplate",
+      requestType = com.google.cloud.dataproc.v1beta2.UpdateWorkflowTemplateRequest.class,
+      responseType = com.google.cloud.dataproc.v1beta2.WorkflowTemplate.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.UpdateWorkflowTemplateRequest,
           com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
       getUpdateWorkflowTemplateMethod() {
-    return getUpdateWorkflowTemplateMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.UpdateWorkflowTemplateRequest,
-          com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
-      getUpdateWorkflowTemplateMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.UpdateWorkflowTemplateRequest,
             com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
@@ -341,9 +283,7 @@ public final class WorkflowTemplateServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.WorkflowTemplateService",
-                              "UpdateWorkflowTemplate"))
+                          generateFullMethodName(SERVICE_NAME, "UpdateWorkflowTemplate"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -363,30 +303,20 @@ public final class WorkflowTemplateServiceGrpc {
     return getUpdateWorkflowTemplateMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListWorkflowTemplatesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesRequest,
-          com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesResponse>
-      METHOD_LIST_WORKFLOW_TEMPLATES = getListWorkflowTemplatesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesRequest,
           com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesResponse>
       getListWorkflowTemplatesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListWorkflowTemplates",
+      requestType = com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesRequest.class,
+      responseType = com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesRequest,
           com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesResponse>
       getListWorkflowTemplatesMethod() {
-    return getListWorkflowTemplatesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesRequest,
-          com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesResponse>
-      getListWorkflowTemplatesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesRequest,
             com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesResponse>
@@ -406,9 +336,7 @@ public final class WorkflowTemplateServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.WorkflowTemplateService",
-                              "ListWorkflowTemplates"))
+                          generateFullMethodName(SERVICE_NAME, "ListWorkflowTemplates"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -428,30 +356,20 @@ public final class WorkflowTemplateServiceGrpc {
     return getListWorkflowTemplatesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteWorkflowTemplateMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.DeleteWorkflowTemplateRequest,
-          com.google.protobuf.Empty>
-      METHOD_DELETE_WORKFLOW_TEMPLATE = getDeleteWorkflowTemplateMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.DeleteWorkflowTemplateRequest,
           com.google.protobuf.Empty>
       getDeleteWorkflowTemplateMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteWorkflowTemplate",
+      requestType = com.google.cloud.dataproc.v1beta2.DeleteWorkflowTemplateRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.dataproc.v1beta2.DeleteWorkflowTemplateRequest,
           com.google.protobuf.Empty>
       getDeleteWorkflowTemplateMethod() {
-    return getDeleteWorkflowTemplateMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.dataproc.v1beta2.DeleteWorkflowTemplateRequest,
-          com.google.protobuf.Empty>
-      getDeleteWorkflowTemplateMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.dataproc.v1beta2.DeleteWorkflowTemplateRequest,
             com.google.protobuf.Empty>
@@ -471,9 +389,7 @@ public final class WorkflowTemplateServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.dataproc.v1beta2.WorkflowTemplateService",
-                              "DeleteWorkflowTemplate"))
+                          generateFullMethodName(SERVICE_NAME, "DeleteWorkflowTemplate"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -494,19 +410,43 @@ public final class WorkflowTemplateServiceGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static WorkflowTemplateServiceStub newStub(io.grpc.Channel channel) {
-    return new WorkflowTemplateServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<WorkflowTemplateServiceStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<WorkflowTemplateServiceStub>() {
+          @java.lang.Override
+          public WorkflowTemplateServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new WorkflowTemplateServiceStub(channel, callOptions);
+          }
+        };
+    return WorkflowTemplateServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static WorkflowTemplateServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new WorkflowTemplateServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<WorkflowTemplateServiceBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<WorkflowTemplateServiceBlockingStub>() {
+          @java.lang.Override
+          public WorkflowTemplateServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new WorkflowTemplateServiceBlockingStub(channel, callOptions);
+          }
+        };
+    return WorkflowTemplateServiceBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static WorkflowTemplateServiceFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new WorkflowTemplateServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<WorkflowTemplateServiceFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<WorkflowTemplateServiceFutureStub>() {
+          @java.lang.Override
+          public WorkflowTemplateServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new WorkflowTemplateServiceFutureStub(channel, callOptions);
+          }
+        };
+    return WorkflowTemplateServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -530,7 +470,7 @@ public final class WorkflowTemplateServiceGrpc {
         com.google.cloud.dataproc.v1beta2.CreateWorkflowTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateWorkflowTemplateMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateWorkflowTemplateMethod(), responseObserver);
     }
 
     /**
@@ -546,7 +486,7 @@ public final class WorkflowTemplateServiceGrpc {
         com.google.cloud.dataproc.v1beta2.GetWorkflowTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetWorkflowTemplateMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetWorkflowTemplateMethod(), responseObserver);
     }
 
     /**
@@ -574,7 +514,7 @@ public final class WorkflowTemplateServiceGrpc {
     public void instantiateWorkflowTemplate(
         com.google.cloud.dataproc.v1beta2.InstantiateWorkflowTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getInstantiateWorkflowTemplateMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getInstantiateWorkflowTemplateMethod(), responseObserver);
     }
 
     /**
@@ -605,8 +545,7 @@ public final class WorkflowTemplateServiceGrpc {
     public void instantiateInlineWorkflowTemplate(
         com.google.cloud.dataproc.v1beta2.InstantiateInlineWorkflowTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(
-          getInstantiateInlineWorkflowTemplateMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getInstantiateInlineWorkflowTemplateMethod(), responseObserver);
     }
 
     /**
@@ -621,7 +560,7 @@ public final class WorkflowTemplateServiceGrpc {
         com.google.cloud.dataproc.v1beta2.UpdateWorkflowTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateWorkflowTemplateMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateWorkflowTemplateMethod(), responseObserver);
     }
 
     /**
@@ -635,7 +574,7 @@ public final class WorkflowTemplateServiceGrpc {
         com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListWorkflowTemplatesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListWorkflowTemplatesMethod(), responseObserver);
     }
 
     /**
@@ -648,56 +587,56 @@ public final class WorkflowTemplateServiceGrpc {
     public void deleteWorkflowTemplate(
         com.google.cloud.dataproc.v1beta2.DeleteWorkflowTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteWorkflowTemplateMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteWorkflowTemplateMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getCreateWorkflowTemplateMethodHelper(),
+              getCreateWorkflowTemplateMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.CreateWorkflowTemplateRequest,
                       com.google.cloud.dataproc.v1beta2.WorkflowTemplate>(
                       this, METHODID_CREATE_WORKFLOW_TEMPLATE)))
           .addMethod(
-              getGetWorkflowTemplateMethodHelper(),
+              getGetWorkflowTemplateMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.GetWorkflowTemplateRequest,
                       com.google.cloud.dataproc.v1beta2.WorkflowTemplate>(
                       this, METHODID_GET_WORKFLOW_TEMPLATE)))
           .addMethod(
-              getInstantiateWorkflowTemplateMethodHelper(),
+              getInstantiateWorkflowTemplateMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.InstantiateWorkflowTemplateRequest,
                       com.google.longrunning.Operation>(
                       this, METHODID_INSTANTIATE_WORKFLOW_TEMPLATE)))
           .addMethod(
-              getInstantiateInlineWorkflowTemplateMethodHelper(),
+              getInstantiateInlineWorkflowTemplateMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.InstantiateInlineWorkflowTemplateRequest,
                       com.google.longrunning.Operation>(
                       this, METHODID_INSTANTIATE_INLINE_WORKFLOW_TEMPLATE)))
           .addMethod(
-              getUpdateWorkflowTemplateMethodHelper(),
+              getUpdateWorkflowTemplateMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.UpdateWorkflowTemplateRequest,
                       com.google.cloud.dataproc.v1beta2.WorkflowTemplate>(
                       this, METHODID_UPDATE_WORKFLOW_TEMPLATE)))
           .addMethod(
-              getListWorkflowTemplatesMethodHelper(),
+              getListWorkflowTemplatesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesRequest,
                       com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesResponse>(
                       this, METHODID_LIST_WORKFLOW_TEMPLATES)))
           .addMethod(
-              getDeleteWorkflowTemplateMethodHelper(),
+              getDeleteWorkflowTemplateMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.dataproc.v1beta2.DeleteWorkflowTemplateRequest,
@@ -715,11 +654,7 @@ public final class WorkflowTemplateServiceGrpc {
    * </pre>
    */
   public static final class WorkflowTemplateServiceStub
-      extends io.grpc.stub.AbstractStub<WorkflowTemplateServiceStub> {
-    private WorkflowTemplateServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<WorkflowTemplateServiceStub> {
     private WorkflowTemplateServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -742,7 +677,7 @@ public final class WorkflowTemplateServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateWorkflowTemplateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateWorkflowTemplateMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -761,7 +696,7 @@ public final class WorkflowTemplateServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetWorkflowTemplateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetWorkflowTemplateMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -792,7 +727,7 @@ public final class WorkflowTemplateServiceGrpc {
         com.google.cloud.dataproc.v1beta2.InstantiateWorkflowTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getInstantiateWorkflowTemplateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getInstantiateWorkflowTemplateMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -826,8 +761,7 @@ public final class WorkflowTemplateServiceGrpc {
         com.google.cloud.dataproc.v1beta2.InstantiateInlineWorkflowTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel()
-              .newCall(getInstantiateInlineWorkflowTemplateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getInstantiateInlineWorkflowTemplateMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -845,7 +779,7 @@ public final class WorkflowTemplateServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateWorkflowTemplateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateWorkflowTemplateMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -862,7 +796,7 @@ public final class WorkflowTemplateServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListWorkflowTemplatesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListWorkflowTemplatesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -878,7 +812,7 @@ public final class WorkflowTemplateServiceGrpc {
         com.google.cloud.dataproc.v1beta2.DeleteWorkflowTemplateRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteWorkflowTemplateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteWorkflowTemplateMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -893,11 +827,7 @@ public final class WorkflowTemplateServiceGrpc {
    * </pre>
    */
   public static final class WorkflowTemplateServiceBlockingStub
-      extends io.grpc.stub.AbstractStub<WorkflowTemplateServiceBlockingStub> {
-    private WorkflowTemplateServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<WorkflowTemplateServiceBlockingStub> {
     private WorkflowTemplateServiceBlockingStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -919,7 +849,7 @@ public final class WorkflowTemplateServiceGrpc {
     public com.google.cloud.dataproc.v1beta2.WorkflowTemplate createWorkflowTemplate(
         com.google.cloud.dataproc.v1beta2.CreateWorkflowTemplateRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateWorkflowTemplateMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateWorkflowTemplateMethod(), getCallOptions(), request);
     }
 
     /**
@@ -934,7 +864,7 @@ public final class WorkflowTemplateServiceGrpc {
     public com.google.cloud.dataproc.v1beta2.WorkflowTemplate getWorkflowTemplate(
         com.google.cloud.dataproc.v1beta2.GetWorkflowTemplateRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetWorkflowTemplateMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetWorkflowTemplateMethod(), getCallOptions(), request);
     }
 
     /**
@@ -962,7 +892,7 @@ public final class WorkflowTemplateServiceGrpc {
     public com.google.longrunning.Operation instantiateWorkflowTemplate(
         com.google.cloud.dataproc.v1beta2.InstantiateWorkflowTemplateRequest request) {
       return blockingUnaryCall(
-          getChannel(), getInstantiateWorkflowTemplateMethodHelper(), getCallOptions(), request);
+          getChannel(), getInstantiateWorkflowTemplateMethod(), getCallOptions(), request);
     }
 
     /**
@@ -993,10 +923,7 @@ public final class WorkflowTemplateServiceGrpc {
     public com.google.longrunning.Operation instantiateInlineWorkflowTemplate(
         com.google.cloud.dataproc.v1beta2.InstantiateInlineWorkflowTemplateRequest request) {
       return blockingUnaryCall(
-          getChannel(),
-          getInstantiateInlineWorkflowTemplateMethodHelper(),
-          getCallOptions(),
-          request);
+          getChannel(), getInstantiateInlineWorkflowTemplateMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1010,7 +937,7 @@ public final class WorkflowTemplateServiceGrpc {
     public com.google.cloud.dataproc.v1beta2.WorkflowTemplate updateWorkflowTemplate(
         com.google.cloud.dataproc.v1beta2.UpdateWorkflowTemplateRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateWorkflowTemplateMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateWorkflowTemplateMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1023,7 +950,7 @@ public final class WorkflowTemplateServiceGrpc {
     public com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesResponse listWorkflowTemplates(
         com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListWorkflowTemplatesMethodHelper(), getCallOptions(), request);
+          getChannel(), getListWorkflowTemplatesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1036,7 +963,7 @@ public final class WorkflowTemplateServiceGrpc {
     public com.google.protobuf.Empty deleteWorkflowTemplate(
         com.google.cloud.dataproc.v1beta2.DeleteWorkflowTemplateRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteWorkflowTemplateMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteWorkflowTemplateMethod(), getCallOptions(), request);
     }
   }
 
@@ -1049,11 +976,7 @@ public final class WorkflowTemplateServiceGrpc {
    * </pre>
    */
   public static final class WorkflowTemplateServiceFutureStub
-      extends io.grpc.stub.AbstractStub<WorkflowTemplateServiceFutureStub> {
-    private WorkflowTemplateServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<WorkflowTemplateServiceFutureStub> {
     private WorkflowTemplateServiceFutureStub(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
@@ -1077,7 +1000,7 @@ public final class WorkflowTemplateServiceGrpc {
         createWorkflowTemplate(
             com.google.cloud.dataproc.v1beta2.CreateWorkflowTemplateRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateWorkflowTemplateMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateWorkflowTemplateMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1093,7 +1016,7 @@ public final class WorkflowTemplateServiceGrpc {
             com.google.cloud.dataproc.v1beta2.WorkflowTemplate>
         getWorkflowTemplate(com.google.cloud.dataproc.v1beta2.GetWorkflowTemplateRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetWorkflowTemplateMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetWorkflowTemplateMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1122,8 +1045,7 @@ public final class WorkflowTemplateServiceGrpc {
         instantiateWorkflowTemplate(
             com.google.cloud.dataproc.v1beta2.InstantiateWorkflowTemplateRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getInstantiateWorkflowTemplateMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getInstantiateWorkflowTemplateMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1155,8 +1077,7 @@ public final class WorkflowTemplateServiceGrpc {
         instantiateInlineWorkflowTemplate(
             com.google.cloud.dataproc.v1beta2.InstantiateInlineWorkflowTemplateRequest request) {
       return futureUnaryCall(
-          getChannel()
-              .newCall(getInstantiateInlineWorkflowTemplateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getInstantiateInlineWorkflowTemplateMethod(), getCallOptions()),
           request);
     }
 
@@ -1173,7 +1094,7 @@ public final class WorkflowTemplateServiceGrpc {
         updateWorkflowTemplate(
             com.google.cloud.dataproc.v1beta2.UpdateWorkflowTemplateRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateWorkflowTemplateMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateWorkflowTemplateMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1188,7 +1109,7 @@ public final class WorkflowTemplateServiceGrpc {
         listWorkflowTemplates(
             com.google.cloud.dataproc.v1beta2.ListWorkflowTemplatesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListWorkflowTemplatesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListWorkflowTemplatesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1202,7 +1123,7 @@ public final class WorkflowTemplateServiceGrpc {
         deleteWorkflowTemplate(
             com.google.cloud.dataproc.v1beta2.DeleteWorkflowTemplateRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteWorkflowTemplateMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteWorkflowTemplateMethod(), getCallOptions()), request);
     }
   }
 
@@ -1335,13 +1256,13 @@ public final class WorkflowTemplateServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new WorkflowTemplateServiceFileDescriptorSupplier())
-                      .addMethod(getCreateWorkflowTemplateMethodHelper())
-                      .addMethod(getGetWorkflowTemplateMethodHelper())
-                      .addMethod(getInstantiateWorkflowTemplateMethodHelper())
-                      .addMethod(getInstantiateInlineWorkflowTemplateMethodHelper())
-                      .addMethod(getUpdateWorkflowTemplateMethodHelper())
-                      .addMethod(getListWorkflowTemplatesMethodHelper())
-                      .addMethod(getDeleteWorkflowTemplateMethodHelper())
+                      .addMethod(getCreateWorkflowTemplateMethod())
+                      .addMethod(getGetWorkflowTemplateMethod())
+                      .addMethod(getInstantiateWorkflowTemplateMethod())
+                      .addMethod(getInstantiateInlineWorkflowTemplateMethod())
+                      .addMethod(getUpdateWorkflowTemplateMethod())
+                      .addMethod(getListWorkflowTemplatesMethod())
+                      .addMethod(getDeleteWorkflowTemplateMethod())
                       .build();
         }
       }

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,20 +1,21 @@
 {
-  "updateTime": "2020-03-19T09:10:47.031190Z",
+  "updateTime": "2020-03-19T23:21:12.111145Z",
   "sources": [
     {
-      "generator": {
-        "name": "artman",
-        "version": "1.1.1",
-        "dockerImage": "googleapis/artman@sha256:5ef340c8d9334719bc5c6981d95f4a5d2737b0a6a24f2b9a0d430e96fff85c5b"
+      "git": {
+        "name": "googleapis",
+        "remote": "https://github.com/googleapis/googleapis.git",
+        "sha": "c8c8c0bd15d082db9546253dbaad1087c7a9782c",
+        "internalRef": "301843591"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "275fbcce2c900278d487c33293a3c7e1fbcd3a34",
-        "internalRef": "301661567",
-        "log": "275fbcce2c900278d487c33293a3c7e1fbcd3a34\nfeat: pubsub/v1 add an experimental filter field to Subscription\n\nPiperOrigin-RevId: 301661567\n\nf2b18cec51d27c999ad30011dba17f3965677e9c\nFix: UpdateBackupRequest.backup is a resource, not a resource reference - remove annotation.\n\nPiperOrigin-RevId: 301636171\n\n800384063ac93a0cac3a510d41726fa4b2cd4a83\nCloud Billing Budget API v1beta1\nModified api documentation to include warnings about the new filter field.\n\nPiperOrigin-RevId: 301634389\n\n0cc6c146b660db21f04056c3d58a4b752ee445e3\nCloud Billing Budget API v1alpha1\nModified api documentation to include warnings about the new filter field.\n\nPiperOrigin-RevId: 301630018\n\nff2ea00f69065585c3ac0993c8b582af3b6fc215\nFix: Add resource definition for a parent of InspectTemplate which was otherwise missing.\n\nPiperOrigin-RevId: 301623052\n\n55fa441c9daf03173910760191646399338f2b7c\nAdd proto definition for AccessLevel, AccessPolicy, and ServicePerimeter.\n\nPiperOrigin-RevId: 301620844\n\ne7b10591c5408a67cf14ffafa267556f3290e262\nCloud Bigtable Managed Backup service and message proto files.\n\nPiperOrigin-RevId: 301585144\n\nd8e226f702f8ddf92915128c9f4693b63fb8685d\nfeat: Add time-to-live in a queue for builds\n\nPiperOrigin-RevId: 301579876\n\n430375af011f8c7a5174884f0d0e539c6ffa7675\ndocs: add missing closing backtick\n\nPiperOrigin-RevId: 301538851\n\n0e9f1f60ded9ad1c2e725e37719112f5b487ab65\nbazel: Use latest release of gax_java\n\nPiperOrigin-RevId: 301480457\n\n5058c1c96d0ece7f5301a154cf5a07b2ad03a571\nUpdate GAPIC v2 with batching parameters for Logging API\n\nPiperOrigin-RevId: 301443847\n\n"
+        "sha": "c8c8c0bd15d082db9546253dbaad1087c7a9782c",
+        "internalRef": "301843591",
+        "log": "c8c8c0bd15d082db9546253dbaad1087c7a9782c\nchore: use latest gapic-generator in bazel WORKSPACE.\nincluding the following commits from gapic-generator:\n- feat: take source protos in all sub-packages (#3144)\n\nPiperOrigin-RevId: 301843591\n\ne4daf5202ea31cb2cb6916fdbfa9d6bd771aeb4c\nAdd bazel file for v1 client lib generation\n\nPiperOrigin-RevId: 301802926\n\n"
       }
     },
     {
@@ -32,8 +33,7 @@
         "apiName": "dataproc",
         "apiVersion": "v1",
         "language": "java",
-        "generator": "gapic",
-        "config": "google/cloud/dataproc/artman_dataproc_v1.yaml"
+        "generator": "bazel"
       }
     },
     {
@@ -42,8 +42,7 @@
         "apiName": "dataproc",
         "apiVersion": "v1beta2",
         "language": "java",
-        "generator": "gapic",
-        "config": "google/cloud/dataproc/artman_dataproc_v1beta2.yaml"
+        "generator": "bazel"
       }
     }
   ]

--- a/synth.py
+++ b/synth.py
@@ -14,22 +14,16 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import synthtool as s
-import synthtool.gcp as gcp
 import synthtool.languages.java as java
-
-gapic = gcp.GAPICGenerator()
 
 service = 'dataproc'
 versions = ['v1', 'v1beta2']
 
 for version in versions:
-  java.gapic_library(
-    service=service,
-    version=version,
-    config_pattern='/google/cloud/dataproc/artman_dataproc_{version}.yaml',
-    package_pattern='com.google.cloud.{service}.{version}',
-    gapic=gapic,
+  java.bazel_library(
+      service=service,
+      version=version,
+      bazel_target=f'//google/cloud/{service}/{version}:google-cloud-{service}-{version}-java',
   )
 
 java.common_templates()


### PR DESCRIPTION
The changes in grpc stubs are caused by the gRPC upgrade from 1.10 (more than a year old) to 1.27 (same version which is used as runtime dependency)
