### PR TITLE
chore: updating codeowners with api-dataproc team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,8 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 # The @googleapis/yoshi-java is the default owner for changes in this repo
-*                       @googleapis/yoshi-java @googleapis/yoshi-java
-**/*.java               @googleapis/yoshi-java
+*                       @googleapis/api-dataproc @googleapis/yoshi-java
+**/*.java               @googleapis/api-dataproc @googleapis/yoshi-java
 
 # The java-samples-reviewers team is the default owner for samples changes
-samples/**/*.java       @googleapis/java-samples-reviewers
+samples/**/*.java       @googleapis/api-dataproc @googleapis/java-samples-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,8 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 # The @googleapis/yoshi-java is the default owner for changes in this repo
-*                       @googleapis/api-dataproc @googleapis/yoshi-java
-**/*.java               @googleapis/api-dataproc @googleapis/yoshi-java
+*                       @googleapis/yoshi-java @googleapis/yoshi-java
+**/*.java               @googleapis/yoshi-java
 
 # The java-samples-reviewers team is the default owner for samples changes
-samples/**/*.java       @googleapis/api-dataproc @googleapis/java-samples-reviewers
+samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,7 +9,7 @@
   "repo": "googleapis/java-dataproc",
   "repo_short": "java-dataproc",
   "distribution_name": "com.google.cloud:google-cloud-dataproc",
-  "codeowner_team": "@googleapis/yoshi-java",
+  "codeowner_team": "@googleapis/api-dataproc",
   "api_id": "dataproc.googleapis.com",
   "transport": "grpc",
   "requires_billing": true,


### PR DESCRIPTION
Adding @googleapis/api-dataproc team to codeowners
