### PR TITLE
samples: fixing machine type for new default image

### DIFF
--- a/samples/snippets/src/main/java/CreateCluster.java
+++ b/samples/snippets/src/main/java/CreateCluster.java
@@ -51,12 +51,12 @@ public class CreateCluster {
       // Configure the settings for our cluster.
       InstanceGroupConfig masterConfig =
           InstanceGroupConfig.newBuilder()
-              .setMachineTypeUri("n1-standard-1")
+              .setMachineTypeUri("n1-standard-2")
               .setNumInstances(1)
               .build();
       InstanceGroupConfig workerConfig =
           InstanceGroupConfig.newBuilder()
-              .setMachineTypeUri("n1-standard-1")
+              .setMachineTypeUri("n1-standard-2")
               .setNumInstances(2)
               .build();
       ClusterConfig clusterConfig =

--- a/samples/snippets/src/main/java/CreateClusterWithAutoscaling.java
+++ b/samples/snippets/src/main/java/CreateClusterWithAutoscaling.java
@@ -138,12 +138,12 @@ public class CreateClusterWithAutoscaling {
       // Configure the settings for our cluster.
       InstanceGroupConfig masterConfig =
           InstanceGroupConfig.newBuilder()
-              .setMachineTypeUri("n1-standard-1")
+              .setMachineTypeUri("n1-standard-2")
               .setNumInstances(1)
               .build();
       InstanceGroupConfig workerConfig =
           InstanceGroupConfig.newBuilder()
-              .setMachineTypeUri("n1-standard-1")
+              .setMachineTypeUri("n1-standard-2")
               .setNumInstances(2)
               .build();
       ClusterConfig clusterConfig =

--- a/samples/snippets/src/main/java/Quickstart.java
+++ b/samples/snippets/src/main/java/Quickstart.java
@@ -79,12 +79,12 @@ public class Quickstart {
       // Configure the settings for our cluster.
       InstanceGroupConfig masterConfig =
           InstanceGroupConfig.newBuilder()
-              .setMachineTypeUri("n1-standard-1")
+              .setMachineTypeUri("n1-standard-2")
               .setNumInstances(1)
               .build();
       InstanceGroupConfig workerConfig =
           InstanceGroupConfig.newBuilder()
-              .setMachineTypeUri("n1-standard-1")
+              .setMachineTypeUri("n1-standard-2")
               .setNumInstances(2)
               .build();
       ClusterConfig clusterConfig =


### PR DESCRIPTION
Dataproc 2.0 is the new default image which does not support n1-standard-1. Sample corrects for this.

Fixes https://github.com/googleapis/java-dataproc/issues/485, https://github.com/googleapis/java-dataproc/issues/486, https://github.com/googleapis/java-dataproc/issues/487
